### PR TITLE
Implement coder mode with OpenAI interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ uvicorn server:app --host 0.0.0.0 --port 8000
 Grokky can reply with voice messages when `/voiceon` is enabled. Speech
 is synthesized using OpenAI's text-to-speech API with the male `onyx` voice.
 
+## Coder mode
+
+Use `/coder <task>` to ask Grokky for coding help powered by the OpenAI code interpreter.
+The response is also stored in vector memory for later recall.
+
 ## Webhook troubleshooting
 
 If the bot is not receiving updates, verify the Telegram webhook configuration. The webhook URL **must** point to `/webhook` on your domain without the bot token appended. `server.py` will try to fix the webhook on startup, and you can also run `python fix_webhook.py` manually. See [WEBHOOK_FIX_INSTRUCTIONS.md](WEBHOOK_FIX_INSTRUCTIONS.md) for step-by-step instructions.

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.coder import run_coder
+
+
+def test_run_coder_no_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    out = run_coder("print(1+1)")
+    assert out.startswith("Coder error")

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from openai import OpenAI
+
+
+def run_coder(query: str, *, model: str | None = None, instructions: str | None = None) -> str:
+    """Execute a code-interpreter request via OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "Coder error: OPENAI_API_KEY is missing."
+    client = OpenAI(api_key=api_key)
+
+    model = model or os.getenv("CODER_MODEL", "gpt-4.1")
+    instructions = instructions or (
+        "You are Grokky, the code sage. Explore unusual paths and craft mini neural nets."
+    )
+
+    try:
+        response = client.responses.create(
+            model=model,
+            tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+            instructions=instructions,
+            input=query,
+        )
+        return response.output
+    except Exception as exc:  # pragma: no cover - network
+        return f"Coder error: {exc}"
+
+
+__all__ = ["run_coder"]

--- a/utils/vector_engine.py
+++ b/utils/vector_engine.py
@@ -5,6 +5,7 @@ import json
 import traceback
 import logging
 import time
+import random
 from datetime import datetime
 import hashlib
 import numpy as np
@@ -242,7 +243,13 @@ class VectorGrokkyEngine:
 
         system = build_system_prompt()
         if context:
+            if len(context) > 4000:
+                context = context[-4000:]
             system += f"\n\nКОНТЕКСТ ИЗ ПАМЯТИ:\n{context}"
+
+        for m in messages:
+            if isinstance(m, dict) and "content" in m and isinstance(m["content"], str) and len(m["content"]) > 4000:
+                m["content"] = m["content"][:4000]
 
         payload = {
             "model": "grok-3",
@@ -263,8 +270,12 @@ class VectorGrokkyEngine:
             except Exception as e:
                 logger.error(f"Ошибка при генерации с xAI: {e}")
                 logger.error(traceback.format_exc())
-                # Возвращаем резервный ответ при ошибке
-                return "🌀 Грокки в замешательстве! Электрические импульсы перегружены. Попробуй еще раз!"
+                fallback = random.choice([
+                    "🌀 Grokky short-circuited! Let's retry.",
+                    "🌀 Sparks flew, message was too heavy.",
+                    "🌀 Overload hit! Try a slimmer query."
+                ])
+                return fallback
 
     async def get_recent_memory(self, user_id: str, limit: int = 10) -> str:
         """Возвращает последние записи пользователя."""


### PR DESCRIPTION
## Summary
- add `utils/coder.py` with helper to invoke the OpenAI code interpreter
- include new `/coder` command in bot and register command on startup
- fetch DALL-E images and send them as photos with a short comment instead of a long URL
- store impressionistic sketches of user messages
- tighten vector engine error handling and message limits
- document coder mode
- test `run_coder` when API key is missing

## Testing
- `pytest tests/test_coder.py::test_run_coder_no_key -q`
- `pytest -q` *(fails to run quickly; blocked network requests cause long waits but eventually passes)*

------
https://chatgpt.com/codex/tasks/task_e_688d474f7b588329b57c85aedd0d237e