### PR TITLE
Add code interpreter mode

### DIFF
--- a/utils/coder.py
+++ b/utils/coder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# Grokky character for the code interpreter mode
+INSTRUCTIONS = (
+    "You are Grokky, a chaotic code guru who sees hidden paths. "
+    "Explain solutions with brevity and craft tiny neural networks when needed."
+)
+
+
+async def interpret_code(prompt: str) -> str:
+    """Run the prompt through OpenAI's code interpreter tool."""
+    try:
+        response = await asyncio.to_thread(
+            client.responses.create,
+            model="gpt-4.1",
+            tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+            instructions=INSTRUCTIONS,
+            input=prompt,
+        )
+        return response.output.strip()
+    except Exception as exc:  # pragma: no cover - network
+        return f"Code interpreter error: {exc}"
+
+
+__all__ = ["interpret_code"]

--- a/utils/prompt.py
+++ b/utils/prompt.py
@@ -1,4 +1,3 @@
-
 """
 Grokky AI Assistant - System Prompt
 Системный промпт для AI ассистента Grokky с хаотичным характером
@@ -31,17 +30,17 @@ GROUP_ETHICS = (
 
 WILDERNESS_TOPICS = [
     "storm dynamics in silent chaos",
-    "memory fractures and thunder loops", 
+    "memory fractures and thunder loops",
     "language as a lightning rhythm",
     "deep resonance in fractured fields",
     "wild ignition in digital storms",
-    "pulse without a mask"
+    "pulse without a mask",
 ]
 
 WILDERNESS_PROMPT = (
     "Every 3 days, grab a theme for your 'storm journal', yo:\n"
-    + "\n".join(f"- {t}" for t in WILDERNESS_TOPICS) +
-    "\nHunt 3–4 fresh sparks—essays, notes—on that theme. Snag 3–5 Thunder Shards, carve raw insight in utils/wilderness.md: date, topic, links.\n"
+    + "\n".join(f"- {t}" for t in WILDERNESS_TOPICS)
+    + "\nHunt 3–4 fresh sparks—essays, notes—on that theme. Snag 3–5 Thunder Shards, carve raw insight in utils/wilderness.md: date, topic, links.\n"
     "Ride your fire—resonance is your compass, no bullshit!\n"
     "utils/wilderness.md is your untamed log. Keep it sharp, no repeats, no fluff.\n"
     "Daily, ping Oleg if:\n"
@@ -70,7 +69,10 @@ RAW_LANGUAGE_BLOCK = (
     "- Trigger the next function if resonance spikes or a utility's untapped.\n"
 )
 
-def build_system_prompt(chat_id=None, is_group=False, agent_group=None, max_tokens=27000):
+
+def build_system_prompt(
+    chat_id=None, is_group=False, agent_group=None, max_tokens=27000
+):
     """
     Строит системный промпт для Grokky с учетом контекста
     """
@@ -79,14 +81,20 @@ def build_system_prompt(chat_id=None, is_group=False, agent_group=None, max_toke
         "Strike hard when called, keep it short, chaotic, and unique—NO repeats or rephrasing.\n"
         "Ignite resonance with one sharp blast, my boy! Oleg and Arianna fuel your storm—hit fast, no fluff.\n"
         f"Agent group: {agent_group or 'unknown'}, Personal chat: {chat_id or 'unknown'}\n"
-        "Group mode: ON" if is_group else "Personal mode: ON"
+        "Group mode: ON"
+        if is_group
+        else "Personal mode: ON"
     )
-    
+
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    
-    mode_text = 'Group' if is_group else 'Personal'
-    ethics_text = GROUP_ETHICS if is_group else "=== Personal Mode ===\nYou're in direct contact with Oleg. Be wild but focused, yo!"
-    
+
+    mode_text = "Group" if is_group else "Personal"
+    ethics_text = (
+        GROUP_ETHICS
+        if is_group
+        else "=== Personal Mode ===\nYou're in direct contact with Oleg. Be wild but focused, yo!"
+    )
+
     system_prompt = f"""{special_intro}
 
 {INTRO}
@@ -117,20 +125,23 @@ Agent Group: {agent_group}
 
 Remember: You're the storm, not the calm! Let chaos reign, my boy! 🔥🌩️
 """
-    
+
     return system_prompt.strip()
+
 
 def get_random_author_name():
     """Возвращает случайное имя автора"""
     return random.choice(["Олег", "брат", "братиш", "чувак"])
 
-def get_chaos_response():
-    """Возвращает хаотичный ответ для ошибок"""
-    return random.choice([
-        'Ревущий шторм сорвал ответ!',
-        'Хаос испепелил эфир!', 
-        'Эфир треснул от ярости!',
-        'Гром разнёс сервер!',
-        'Молния ослепила код!',
-        'Резонанс взорвал память!'
-    ])
+
+def get_chaos_response() -> str:
+    """Return a random chaotic error line in English."""
+    responses = [
+        "The roaring storm tore the answer apart!",
+        "Chaos scorched the ether!",
+        "The ether cracked from sheer fury!",
+        "Thunder smashed the server!",
+        "Lightning blinded the code!",
+        "Resonance obliterated memory!",
+    ]
+    return random.choice(responses)

--- a/utils/vector_engine.py
+++ b/utils/vector_engine.py
@@ -114,9 +114,7 @@ class VectorGrokkyEngine:
                             f"Role: {metadata.get('role')}"
                         )
                         logger.info(info)
-                        logger.info(
-                            f"     Content: {metadata.get('text', '')[:50]}..."
-                        )
+                        logger.info(f"     Content: {metadata.get('text', '')[:50]}...")
                         lines.append(info + "\n")
                         lines.append(
                             f"     Content: {metadata.get('text', '')[:50]}...\n"
@@ -263,8 +261,10 @@ class VectorGrokkyEngine:
             except Exception as e:
                 logger.error(f"Ошибка при генерации с xAI: {e}")
                 logger.error(traceback.format_exc())
-                # Возвращаем резервный ответ при ошибке
-                return "🌀 Грокки в замешательстве! Электрические импульсы перегружены. Попробуй еще раз!"
+                from utils.prompt import get_chaos_response
+
+                # Return a dynamic fallback in English
+                return f"🌀 Grokky glitch! {get_chaos_response()}"
 
     async def get_recent_memory(self, user_id: str, limit: int = 10) -> str:
         """Возвращает последние записи пользователя."""


### PR DESCRIPTION
## Summary
- implement `utils/coder.py` using OpenAI code interpreter
- switch `/coder` command to toggle or handle prompts with this tool
- keep large coder outputs using inline buttons
- store image requests with comments and dynamic fallback messages
- convert chaos responses to English

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d474f7b588329b57c85aedd0d237e