### PR TITLE
Add SLNCX and coder mode toggles and simplify Wulf engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ A number of tools ship with the repository:
 - **Voice control** – `/voiceon` and `/voiceoff` switch spoken replies using
   OpenAI's text‑to‑speech.
 - **Image generation** – `/imagine <prompt>` asks DALL·E for a picture.
-- **Coder mode** – `/coder` toggles interpretation of small code snippets or
-  executes a single prompt.
-- **SLNCX prompt** – `/slncx <prompt>` sends text straight to the Wulf engine.
+- **Coder mode** – `/coder` enables code interpretation, `/coderoff` disables it.
+- **SLNCX mode** – `/slncx` routes messages to Wulf until `/slncxoff`.
 - **Status checks** – `/status` reports API health and memory usage.
 - **Memory wipes** – `/clearmemory` clears stored vector embeddings.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy>=1.24.0
 pypdf>=3.10.0
 pillow>=10.0.0
 openai>=1.0.0
+requests>=2.31.0

--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -1,0 +1,58 @@
+import os
+import time
+from typing import Optional
+
+import requests
+
+
+def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
+    """Call the Grok-3 API as a dynamic knowledge base."""
+    api_key = api_key or os.getenv("XAI_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    payload = {"prompt": prompt, "max_tokens": 500}
+    try:
+        res = requests.post(
+            "https://api.xai.org/grok-3/generate", json=payload, headers=headers
+        )
+        res.raise_for_status()
+        return res.json().get("text", "")
+    except Exception as exc:  # pragma: no cover - network
+        with open(
+            f"failures/{time.strftime('%Y-%m-%d')}.log", "a", encoding="utf-8"
+        ) as f:
+            f.write(f"{time.time()}: Grok-3 API failed - {exc}\n")
+        return "Grok-3 offline"
+
+
+def query_gpt4(prompt: str, api_key: Optional[str] = None, model: str = "gpt-4o") -> str:
+    """Call the GPT-4 API as a secondary knowledge base."""
+    api_key = api_key or os.getenv("OPENAI_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.8,
+    }
+    try:
+        res = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=30,
+        )
+        res.raise_for_status()
+        return res.json()["choices"][0]["message"]["content"]
+    except Exception as exc:  # pragma: no cover - network
+        with open(
+            f"failures/{time.strftime('%Y-%m-%d')}.log", "a", encoding="utf-8"
+        ) as f:
+            f.write(f"{time.time()}: GPT-4 API failed - {exc}\n")
+        return "GPT-4 offline"
+
+
+def get_dynamic_knowledge(prompt: str, api_key: Optional[str] = None) -> str:
+    """Fetch knowledge from Grok-3 with GPT-4 fallback."""
+    knowledge = query_grok3(prompt, api_key)
+    if knowledge.startswith("Grok-3 offline"):
+        knowledge = query_gpt4(prompt, api_key)
+    return knowledge


### PR DESCRIPTION
## Summary
- Make `/coder` and `/slncx` persistent modes with `/coderoff` and `/slncxoff` to exit
- Route messages through Wulf mode when active and simplify command hints
- Replace Hugging Face loaders with a lightweight dynamic knowledge fetcher
- Document new commands and include `requests` dependency

## Testing
- `python -m flake8 --max-line-length=120 server.py SLNCX/wulf_integration.py utils/dynamic_weights.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d737aa3608329b37d545230fa808f