### PR TITLE
feat: add genesis3 deep reasoning

### DIFF
--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.complexity import estimate_complexity_and_entropy
+
+
+def test_estimate_complexity_basic():
+    msg = "why paradox recursion self meta " * 20
+    complexity, entropy = estimate_complexity_and_entropy(msg)
+    assert complexity == 3
+    assert 0 <= entropy <= 1

--- a/utils/complexity.py
+++ b/utils/complexity.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+
+class ThoughtComplexityLogger:
+    """Log message complexity and entropy for each reasoning turn."""
+
+    def __init__(self):
+        self.logs = []  # timestamp, message, scale, entropy
+
+    def log_turn(self, message: str, complexity_scale: int, entropy: float):
+        record = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "message": message,
+            "complexity_scale": complexity_scale,
+            "entropy": float(entropy),
+        }
+        self.logs.append(record)
+        print(
+            f"LOG@{record['timestamp']} | Complexity: {complexity_scale} | Entropy: {entropy:.3f}"
+        )
+
+    def recent(self, n: int = 7):
+        return self.logs[-n:]
+
+
+def estimate_complexity_and_entropy(msg: str):
+    """Simple heuristic to estimate complexity (1-3) and entropy proxy."""
+    complexity = 1
+    if any(word in msg.lower() for word in ["why", "paradox", "recursive", "self", "meta"]):
+        complexity += 1
+    if len(msg) > 300:
+        complexity += 1
+    entropy = min(1.0, float(len(set(msg.split()))) / 40.0)
+    return min(3, complexity), entropy

--- a/utils/genesis3.py
+++ b/utils/genesis3.py
@@ -1,0 +1,39 @@
+import httpx
+import os
+
+SONAR_PRO_URL = "https://api.perplexity.ai/chat/completions"
+GEN3_MODEL = "sonar-reasoning-pro"
+PRO_HEADERS = {
+    "Authorization": f"Bearer {os.getenv('PPLX_API_KEY')}",
+    "Content-Type": "application/json"
+}
+
+
+async def genesis3_deep_dive(chain_of_thought: str, prompt: str) -> str:
+    """
+    Invoke Sonar Reasoning Pro for deep, infernal, atomized insight.
+    Always returns ONLY the inferential analysis — no links or references.
+    """
+    # (1) Крутой system prompt: инфернальный анализ, запрет ссылок, вывод из вывода
+    SYSTEM_PROMPT = (
+        "You are GENESIS-3, the Infernal Analyst. "
+        "Dissect the user's reasoning into atomic causal steps. "
+        "List hidden variables or paradoxes. Give a 2-sentence meta-conclusion. "
+        "NEVER give references, links, or citations. "
+        "If the logic naturally leads to a deeper paradox — do a further step: "
+        "extract a 'derivative inference' (вывод из вывода), then try to phrase a final paradoxical question."
+    )
+    payload = {
+        "model": GEN3_MODEL,
+        "temperature": 0.65,
+        "max_tokens": 320,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"CHAIN OF THOUGHT:\n{chain_of_thought}"},
+            {"role": "user", "content": f"QUERY:\n{prompt}"}
+        ]
+    }
+    async with httpx.AsyncClient(timeout=60) as cli:
+        r = await cli.post(SONAR_PRO_URL, headers=PRO_HEADERS, json=payload)
+        r.raise_for_status()
+        return r.json()["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- add Sonar Reasoning Pro utility for deep inferential analysis
- log message complexity/entropy and gate genesis3 on max depth
- route replies through genesis2 and optional genesis3 for enriched outputs

## Testing
- `pytest`
- `ruff check utils/genesis3.py utils/complexity.py server.py tests/test_complexity.py`

------
https://chatgpt.com/codex/tasks/task_e_688e0e25edc48329a55b2d022f8a72a1