### PR TITLE
feat: add deep reasoning filter

### DIFF
--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.complexity import (
+    ThoughtComplexityLogger,
+    estimate_complexity_and_entropy,
+)
+
+
+def test_estimate_basic():
+    msg = "simple question"
+    complexity, entropy = estimate_complexity_and_entropy(msg)
+    assert complexity == 1
+    assert 0 <= entropy <= 1
+
+
+def test_estimate_with_keywords():
+    msg = "Why recursion often breeds paradox?"
+    complexity, entropy = estimate_complexity_and_entropy(msg)
+    assert complexity >= 2
+    assert entropy > 0
+
+
+def test_logger_records():
+    logger = ThoughtComplexityLogger()
+    logger.log_turn("hi", 1, 0.5)
+    assert len(logger.logs) == 1
+    assert logger.logs[0]["complexity_scale"] == 1

--- a/tests/test_genesis3.py
+++ b/tests/test_genesis3.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import asyncio
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import genesis3
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def post(self, url, headers, json):
+        return DummyResponse({"choices": [{"message": {"content": "deep"}}]})
+
+
+def test_genesis3_deep_dive(monkeypatch):
+    monkeypatch.setattr(genesis3, "httpx", type("mock", (), {"AsyncClient": DummyClient}))
+    res = asyncio.run(genesis3.genesis3_deep_dive("chain", "prompt"))
+    assert res == "deep"
+

--- a/utils/complexity.py
+++ b/utils/complexity.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+
+class ThoughtComplexityLogger:
+    """Логгер для записи мыслекомплексити и энтропии на каждом ходе."""
+
+    def __init__(self) -> None:
+        self.logs: List[dict] = []  # timestamp, message, scale, entropy
+
+    def log_turn(self, message: str, complexity_scale: int, entropy: float) -> None:
+        record = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "message": message,
+            "complexity_scale": complexity_scale,
+            "entropy": float(entropy),
+        }
+        self.logs.append(record)
+        print(
+            f"LOG@{record['timestamp']} | Complexity: {complexity_scale} | Entropy: {entropy:.3f}"
+        )
+
+    def recent(self, n: int = 7) -> List[dict]:
+        return self.logs[-n:]
+
+
+def estimate_complexity_and_entropy(msg: str) -> tuple[int, float]:
+    """Эвристическая оценка сложности сообщения и его энтропии."""
+    complexity = 1
+    if any(word in msg.lower() for word in ["why", "paradox", "recursive", "self", "meta"]):
+        complexity += 1
+    if len(msg) > 300:
+        complexity += 1
+    entropy = min(1.0, float(len(set(msg.split()))) / 40.0)
+    return min(3, complexity), entropy

--- a/utils/genesis3.py
+++ b/utils/genesis3.py
@@ -1,0 +1,39 @@
+import httpx
+import os
+
+SONAR_PRO_URL = "https://api.perplexity.ai/chat/completions"
+GEN3_MODEL = "sonar-reasoning-pro"
+PRO_HEADERS = {
+    "Authorization": f"Bearer {os.getenv('PPLX_API_KEY')}",
+    "Content-Type": "application/json"
+}
+
+
+async def genesis3_deep_dive(chain_of_thought: str, prompt: str) -> str:
+    """
+    Invoke Sonar Reasoning Pro for deep, infernal, atomized insight.
+    Always returns ONLY the inferential analysis — no links or references.
+    """
+    # (1) Крутой system prompt: инфернальный анализ, запрет ссылок, вывод из вывода
+    SYSTEM_PROMPT = (
+        "You are GENESIS-3, the Infernal Analyst. "
+        "Dissect the user's reasoning into atomic causal steps. "
+        "List hidden variables or paradoxes. Give a 2-sentence meta-conclusion. "
+        "NEVER give references, links, or citations. "
+        "If the logic naturally leads to a deeper paradox — do a further step: "
+        "extract a 'derivative inference' (вывод из вывода), then try to phrase a final paradoxical question."
+    )
+    payload = {
+        "model": GEN3_MODEL,
+        "temperature": 0.65,
+        "max_tokens": 320,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"CHAIN OF THOUGHT:\n{chain_of_thought}"},
+            {"role": "user", "content": f"QUERY:\n{prompt}"}
+        ]
+    }
+    async with httpx.AsyncClient(timeout=60) as cli:
+        r = await cli.post(SONAR_PRO_URL, headers=PRO_HEADERS, json=payload)
+        r.raise_for_status()
+        return r.json()["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- add Sonar Reasoning Pro deep dive utility
- track message complexity/entropy and trigger genesis3 at max depth
- extend message handling to merge core draft, twist, and deep decomposition

## Testing
- `ruff check . --select E9,F63,F7,F82 --quiet` (failed: utils/file_handling.py:221:14: F821 Undefined name `VectorGrokkyEngine`)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e0e25edc48329a55b2d022f8a72a1