### PR TITLE
Handle list outputs from code interpreter

### DIFF
--- a/utils/coder.py
+++ b/utils/coder.py
@@ -23,7 +23,21 @@ async def interpret_code(prompt: str) -> str:
             instructions=INSTRUCTIONS,
             input=prompt,
         )
-        return response.output.strip()
+
+        output = response.output
+        if isinstance(output, str):
+            return output.strip()
+        if isinstance(output, list):
+            parts = []
+            for item in output:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and "text" in item:
+                    parts.append(item["text"])
+                else:
+                    parts.append(str(item))
+            return "".join(parts).strip()
+        return str(output).strip()
     except Exception as exc:  # pragma: no cover - network
         return f"Code interpreter error: {exc}"
 

--- a/utils/knowtheworld.py
+++ b/utils/knowtheworld.py
@@ -67,11 +67,13 @@ async def know_the_world_task(
     if engine is None:
         engine = VectorGrokkyEngine()
 
-    interval = interval or 86400
+    if interval is None:
+        interval = 86400
 
     count = 0
     while True:
-        await asyncio.sleep(random.randint(0, 3600))
+        if interval:
+            await asyncio.sleep(random.randint(0, 3600))
         try:
             city_news = await fetch_news(BOT_LOCATION)
             world_parts = []


### PR DESCRIPTION
## Summary
- make `interpret_code` robust to list outputs from the OpenAI API
- stub out aiogram during tests and defer vector engine initialization
- allow `know_the_world_task` to run immediately when `interval=0`

## Testing
- `ruff check server.py utils/coder.py utils/knowtheworld.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8e99534483298ad0b99f98a9c6b3