### PR TITLE
Allow coder mode without vector engine

### DIFF
--- a/server.py
+++ b/server.py
@@ -341,10 +341,6 @@ async def cmd_clearmemory(message: Message):
 
 async def handle_coder_prompt(message: Message, text: str) -> None:
     """Process a coder-mode prompt via OpenAI code interpreter."""
-    if not engine:
-        await reply_split(message, "🌀 Grokky engine is unavailable")
-        return
-
     chat_id = str(message.chat.id)
     memory_id = (
         f"{chat_id}_{message.from_user.id}"
@@ -352,17 +348,19 @@ async def handle_coder_prompt(message: Message, text: str) -> None:
         else str(message.from_user.id)
     )
 
-    try:
-        await engine.add_memory(memory_id, text, role="user")
-    except Exception:
-        pass
+    if engine:
+        try:
+            await engine.add_memory(memory_id, text, role="user")
+        except Exception:
+            pass
 
     result = await interpret_code(text)
 
-    try:
-        await engine.add_memory(memory_id, result, role="assistant")
-    except Exception:
-        pass
+    if engine:
+        try:
+            await engine.add_memory(memory_id, result, role="assistant")
+        except Exception:
+            pass
 
     if len(result) > 3500:
         CODER_OUTPUT[(message.chat.id, message.from_user.id)] = result

--- a/tests/test_coder_mode.py
+++ b/tests/test_coder_mode.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+
+
+class DummyMessage:
+    def __init__(self):
+        self.chat = type('Chat', (), {'id': 1, 'type': 'private'})()
+        self.from_user = type('User', (), {'id': 42})()
+
+
+@pytest.mark.asyncio
+async def test_handle_coder_prompt_without_engine(monkeypatch):
+    outputs = []
+
+    async def fake_interpret_code(text):
+        return f"code: {text}"
+
+    async def fake_reply_split(message, text):
+        outputs.append(text)
+
+    monkeypatch.setattr(server, 'interpret_code', fake_interpret_code)
+    monkeypatch.setattr(server, 'reply_split', fake_reply_split)
+    server.engine = None
+
+    msg = DummyMessage()
+    await server.handle_coder_prompt(msg, 'print(1)')
+
+    assert outputs == ["code: print(1)"]


### PR DESCRIPTION
## Summary
- allow coder mode to run without a vector engine
- add regression test covering coder prompt handling with no engine

## Testing
- `python -m flake8` (fails: E501, F841, etc.)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eaa6b7a748329bd5e433192059b7d