### PR TITLE
Handle response objects in SLNCX mode

### DIFF
--- a/tests/test_wulf_integration.py
+++ b/tests/test_wulf_integration.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from SLNCX import wulf_integration
+
+
+class FakePiece:
+    def __init__(self, text):
+        self.type = "output_text"
+        self.text = text
+
+
+class FakeMessage:
+    def __init__(self, text):
+        self.content = [FakePiece(text)]
+
+
+class FakeResponse:
+    def __init__(self, text):
+        self.output = [FakeMessage(text)]
+
+
+def test_generate_response_handles_response_objects(monkeypatch):
+    def fake_get_dynamic(prompt, api_key=None):
+        return FakeResponse("ok")
+
+    monkeypatch.setattr(wulf_integration, "get_dynamic_knowledge", fake_get_dynamic)
+    assert wulf_integration.generate_response("hi", "wulf") == "ok"


### PR DESCRIPTION
## Summary
- ensure `generate_response` parses response objects and returns clean text in SLNCX mode
- add unit test covering response object parsing for Wulf mode

## Testing
- `ruff check SLNCX/wulf_integration.py tests/test_wulf_integration.py`
- `ruff check .` *(fails: unused variables and imports in unrelated files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec7dbb5188329aee78ec77eac9379