### PR TITLE
Integrate 42 utility and expand bot command menu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pypdf>=3.10.0
 pillow>=10.0.0
 openai>=1.0.0
 requests>=2.31.0
+beautifulsoup4>=4.12.0

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,21 @@
 
+"""Utility package helpers.
+
+This module exposes convenience imports for modules that use
+non-standard file names.  In particular, :mod:`utils.42` defines the
+function :func:`handle`, but the numeric module name prevents a regular
+``from utils.42 import handle`` import.  To keep the public API simple we
+re-export :func:`handle` here so other modules can just ``from utils
+import handle``.
+"""
+
+from importlib import import_module
+
+# ``42.py`` cannot be imported using a normal statement because the
+# module name starts with a digit.  ``import_module`` allows us to load it
+# dynamically and re-export the ``handle`` coroutine.
+_module_42 = import_module(".42", package=__name__)
+handle = _module_42.handle  # type: ignore[attr-defined]
+
+__all__ = ["handle"]
+


### PR DESCRIPTION
## Summary
- hook up utils/42.py into server, exposing `/when`, `/mars`, `/42`, and `/whatsnew`
- refresh Telegram command menu with new descriptions and options
- harden 42 utility with optional imports, fixed caching, and dynamic export

## Testing
- `pytest`
- `python -m py_compile server.py utils/42.py utils/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6890b081f39883298bbb36763f19b498