### PR TITLE
fix: improve command responses and memory

### DIFF
--- a/server.py
+++ b/server.py
@@ -353,28 +353,36 @@ async def cmd_clearmemory(message: Message):
 @dp.message(Command("when"))
 async def cmd_when(message: Message):
     """Handle /when command via the 42 utility."""
-    result = await handle("when")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    lang = lang.split("-")[0].split("_")[0]
+    result = await handle("when", lang=lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("mars"))
 async def cmd_mars(message: Message):
     """Handle /mars command via the 42 utility."""
-    result = await handle("mars")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    lang = lang.split("-")[0].split("_")[0]
+    result = await handle("mars", lang=lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("42"))
 async def cmd_42(message: Message):
     """Handle /42 command via the 42 utility."""
-    result = await handle("42")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    lang = lang.split("-")[0].split("_")[0]
+    result = await handle("42", lang=lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("whatsnew"))
 async def cmd_whatsnew(message: Message):
     """Handle /whatsnew command via the 42 utility."""
-    result = await handle("whatsnew")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    lang = lang.split("-")[0].split("_")[0]
+    result = await handle("whatsnew", lang=lang)
     await reply_split(message, result["response"])
 
 
@@ -721,9 +729,11 @@ async def handle_42_api(request):
     except Exception:
         data = {}
     cmd = data.get("cmd") or request.query.get("cmd", "")
+    lang = data.get("lang") or request.query.get("lang", "en")
+    lang = lang.split("-")[0].split("_")[0]
     if cmd not in {"when", "mars", "42", "whatsnew"}:
         return web.json_response({"error": "Unsupported command"}, status=400)
-    result = await handle(cmd)
+    result = await handle(cmd, lang=lang)
     return web.json_response(result)
 
 

--- a/utils/hybrid_engine.py
+++ b/utils/hybrid_engine.py
@@ -10,7 +10,8 @@ class HybridGrokkyEngine:
         self.openai_h = {
             "Authorization": f"Bearer {self.openai_key}",
             "Content-Type": "application/json",
-            "OpenAI-Beta": "assistants=v1"
+            # Use the v2 Assistants API to avoid 400 errors on thread creation.
+            "OpenAI-Beta": "assistants=v2",
         }
         self.xai_h = {
             "Authorization": f"Bearer {self.xai_key}",


### PR DESCRIPTION
## Summary
- fix OpenAI header to Assistants API v2 for thread creation
- add language-aware translations and ensure special commands retain links
- allow Telegram and HTTP callers to specify reply language

## Testing
- `flake8 .` *(fails: command not found)*
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca74ee7c8329bd6f3cfe3b5b3ded