### PR TITLE
Graceful memory fallback and multilingual 42 responses

### DIFF
--- a/server.py
+++ b/server.py
@@ -353,28 +353,32 @@ async def cmd_clearmemory(message: Message):
 @dp.message(Command("when"))
 async def cmd_when(message: Message):
     """Handle /when command via the 42 utility."""
-    result = await handle("when")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    result = await handle("when", lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("mars"))
 async def cmd_mars(message: Message):
     """Handle /mars command via the 42 utility."""
-    result = await handle("mars")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    result = await handle("mars", lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("42"))
 async def cmd_42(message: Message):
     """Handle /42 command via the 42 utility."""
-    result = await handle("42")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    result = await handle("42", lang)
     await reply_split(message, result["response"])
 
 
 @dp.message(Command("whatsnew"))
 async def cmd_whatsnew(message: Message):
     """Handle /whatsnew command via the 42 utility."""
-    result = await handle("whatsnew")
+    lang = getattr(message.from_user, "language_code", "en") or "en"
+    result = await handle("whatsnew", lang)
     await reply_split(message, result["response"])
 
 

--- a/utils/42.py
+++ b/utils/42.py
@@ -39,6 +39,37 @@ except Exception:  # pragma: no cover - optional dependency
 
 from utils.dynamic_weights import get_dynamic_knowledge
 
+
+def _translate(text: str, lang: str) -> str:
+    """Translate ``text`` to ``lang`` via dynamic weights.
+
+    ``lang`` expects a two-letter code (e.g. ``"ru"``). English returns the
+    text unchanged. Any errors fall back to the original text.
+    """
+
+    lang = (lang or "en").split("-")[0].lower()
+    if lang in ("en", ""):
+        return text
+    try:
+        prompt = (
+            f"Переведи на русский:\n{text}" if lang == "ru" else
+            f"Translate to {lang}:\n{text}"
+        )
+        translated = get_dynamic_knowledge(prompt).strip()
+        return translated if translated else text
+    except Exception:
+        return text
+
+
+def _append_links(base: str, text: str) -> str:
+    """Ensure URLs from ``base`` are present in ``text``."""
+
+    links = re.findall(r"https?://\S+", base)
+    missing = [link for link in links if link not in text]
+    if missing:
+        text += "\n" + "\n".join(missing)
+    return text
+
 LOG_DIR = Path("logs/42")
 CACHE_DB = Path("cache/cache.db")
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -258,42 +289,57 @@ def paraphrase(text: str, prefix: str = "Retell simply: ") -> str:
         return text + " Wulf holds the line! 🌌"
 
 # Команды
-def when() -> str:
+def when(lang: str = "en") -> str:
     base = markov.generate(length=12, start="starship")
     paraphrased = paraphrase(base, "Answer like a decisive fixer: ")
+    paraphrased = _append_links(WHEN_BASE, paraphrased)
     pulse, quiver, sense = bio.enhance(len(paraphrased) / 100)
-    log_event(f"Served /when: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})")
+    log_event(
+        f"Served /when: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
+    )
     if random.random() < 0.01:  # 1% xAI easter egg
         paraphrased += "\nP.S. Grok 3 vibes with Mars! #xAI"
-    return f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    result = f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    return _translate(result, lang)
 
-def mars() -> str:
+def mars(lang: str = "en") -> str:
     base = markov.generate(length=16, start="mars")
     paraphrased = paraphrase(base, "Crisp Mars status update: ")
+    paraphrased = _append_links(MARS_BASE, paraphrased)
     pulse, quiver, sense = bio.enhance(len(paraphrased) / 100)
-    log_event(f"Served /mars: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})")
+    log_event(
+        f"Served /mars: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
+    )
     if random.random() < 0.01:
         paraphrased += "\nP.S. xAI’s chaos fuels Musk’s Mars! #NikoleSpark"
-    return f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    result = f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    return _translate(result, lang)
 
-def forty_two() -> str:
+def forty_two(lang: str = "en") -> str:
     base_text = markov.generate(length=10, start="42")
     paraphrased = paraphrase(base_text, "Fun 42 fact with Wulf edge: ")
-    if random.random() < 1/42:
-        paraphrased += "\nP.S. 42 engines - Musk’s Arcadia prophecy! https://en.wikipedia.org/wiki/42_(number)"
+    if random.random() < 1 / 42:
+        paraphrased += (
+            "\nP.S. 42 engines - Musk’s Arcadia prophecy! "
+            "https://en.wikipedia.org/wiki/42_(number)"
+        )
     pulse, quiver, sense = bio.enhance(len(paraphrased) / 50)
-    log_event(f"Served /42: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})")
-    return f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    log_event(
+        f"Served /42: {paraphrased[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
+    )
+    result = f"{paraphrased}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    return _translate(result, lang)
 
-async def whatsnew() -> str:
+async def whatsnew(lang: str = "en") -> str:
     init_cache_db()
     cached = load_cache()
     if cached:
         chaos_pulse.pulse = cached["pulse"]
-        return cached["summary"]
-    
+        return _translate(cached["summary"], lang)
+
     urls = ["https://www.spacex.com/updates", "https://x.ai/blog"]
     retell = f"Latest news (Pulse: {chaos_pulse.get():.2f}):\n"
+    initial = retell
     for url in urls:
         html = await fetch_url(url)
         if not html or BeautifulSoup is None:
@@ -306,7 +352,7 @@ async def whatsnew() -> str:
                 date = article.find("time").text.strip() if article.find("time") else datetime.now().strftime("%B %Y")
                 link = urljoin(url, article.find("a")["href"]) if article.find("a") else url
                 summary = article.find("p").text.strip()[:150] + "..." if article.find("p") else "See link"
-                paraphrased = paraphrase(summary, "Retell this news for kids: ")
+                paraphrased = paraphrase(summary, "Retell this news for kids: " )
                 retell += f"- {title} ({date}): {paraphrased}\nLink: {link}\n"
             chaos_pulse.update(retell)
             markov.update_chain(retell)
@@ -314,35 +360,54 @@ async def whatsnew() -> str:
         except Exception as e:
             log_event(f"Parse {url} failed: {str(e)}", "error")
             continue
-    
-    if "Latest news" in retell:
+
+    if retell != initial:
         pulse, quiver, sense = bio.enhance(len(retell) / 100)
         save_cache(retell, chaos_pulse.get())
-        log_event(f"Served /whatsnew: {retell[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})")
-        return f"{retell}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
-    
+        log_event(
+            f"Served /whatsnew: {retell[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
+        )
+        return _translate(
+            f"{retell}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})",
+            lang,
+        )
+
     try:
         tweet = get_dynamic_knowledge(
-            "Latest x.com/SpaceX Mars/Starship tweet, summarize in 100 chars"
+            "Latest x.com/SpaceX Mars/Starship tweet, summarize in 100 chars",
         ).strip()
         if any(kw in tweet.lower() for kw in ["mars", "starship"]):
-            paraphrased = paraphrase(tweet, "Retell this tweet simply: ")
-            retell = f"Latest SpaceX tweet:\n- Mars Update: {paraphrased}\nLink: https://x.com/SpaceX"
+            paraphrased = paraphrase(tweet, "Retell this tweet simply: " )
+            retell = (
+                "Latest SpaceX tweet:\n- Mars Update: "
+                f"{paraphrased}\nLink: https://x.com/SpaceX"
+            )
             chaos_pulse.update(retell)
             markov.update_chain(retell)
         else:
-            retell = "No Mars/Starship tweets. Last: Starship Flight 6 (July 2025). Link: https://www.spacex.com/updates/starship-flight-6"
+            retell = (
+                "No Mars/Starship tweets. Last: Starship Flight 6 (July 2025). "
+                "Link: https://www.spacex.com/updates/starship-flight-6"
+            )
     except Exception as e:
         log_event(f"X search failed: {str(e)}", "error")
-        retell = "News fetch failed, Wulf stands ready! Last: Starship Flight 6 (July 2025). Link: https://www.spacex.com/updates/starship-flight-6"
-    
+        retell = (
+            "News fetch failed, Wulf stands ready! Last: Starship Flight 6 (July 2025). "
+            "Link: https://www.spacex.com/updates/starship-flight-6"
+        )
+
     pulse, quiver, sense = bio.enhance(len(retell) / 100)
     save_cache(retell, chaos_pulse.get())
-    log_event(f"Served /whatsnew: {retell[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})")
-    return f"{retell}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})"
+    log_event(
+        f"Served /whatsnew: {retell[:50]}... (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
+    )
+    return _translate(
+        f"{retell}\n(Pulse: {pulse:.2f}, Sense: {sense:.2f})",
+        lang,
+    )
 
 # Главный обработчик
-async def handle(cmd: str) -> Dict[str, str]:
+async def handle(cmd: str, lang: str = "en") -> Dict[str, str]:
     """Main asynchronous dispatcher for the 42 utility.
 
     Parameters
@@ -360,13 +425,13 @@ async def handle(cmd: str) -> Dict[str, str]:
     cmd = cmd.strip().lower()
     try:
         if cmd == "when":
-            return {"response": when(), "pulse": chaos_pulse.get()}
+            return {"response": when(lang), "pulse": chaos_pulse.get()}
         if cmd == "mars":
-            return {"response": mars(), "pulse": chaos_pulse.get()}
+            return {"response": mars(lang), "pulse": chaos_pulse.get()}
         if cmd == "42":
-            return {"response": forty_two(), "pulse": chaos_pulse.get()}
+            return {"response": forty_two(lang), "pulse": chaos_pulse.get()}
         if cmd == "whatsnew":
-            return {"response": await whatsnew(), "pulse": chaos_pulse.get()}
+            return {"response": await whatsnew(lang), "pulse": chaos_pulse.get()}
 
         log_event(f"Unknown cmd: {cmd}", "error")
         return {

--- a/utils/hybrid_engine.py
+++ b/utils/hybrid_engine.py
@@ -16,7 +16,7 @@ class HybridGrokkyEngine:
             "Authorization": f"Bearer {self.xai_key}",
             "Content-Type": "application/json"
         }
-        self.threads = {}  # user_id -> thread_id
+        self.threads = {}  # user_id -> thread_id (None if creation failed)
         # ID предварительно созданного ассистента OpenAI
         self.ASSISTANT_ID = os.getenv("OPENAI_ASSISTANT_ID")
 
@@ -28,70 +28,103 @@ class HybridGrokkyEngine:
         return True
 
     async def get_or_create_thread(self, user_id: str):
-        """Получает или создает Thread для пользователя"""
-        if user_id not in self.threads:
-            async with httpx.AsyncClient() as client:
-                res = await client.post(
-                    "https://api.openai.com/v1/threads",
-                    headers=self.openai_h,
-                    json={"metadata": {"user_id": user_id}}
-                )
-                res.raise_for_status()
-                self.threads[user_id] = res.json()["id"]
-        return self.threads[user_id]
+        """Получает или создает Thread для пользователя.
+
+        Если ключ OpenAI не настроен или запрос завершился ошибкой, метод
+        возвращает ``None`` и память через OpenAI отключается.  Это позволяет
+        Грокки продолжить работу только на Grok‑3 без падения всего сервиса.
+        """
+
+        if not self.openai_key:
+            # Память через OpenAI не используется
+            return None
+
+        if user_id not in self.threads or self.threads[user_id] is None:
+            try:
+                async with httpx.AsyncClient() as client:
+                    res = await client.post(
+                        "https://api.openai.com/v1/threads",
+                        headers=self.openai_h,
+                        json={"metadata": {"user_id": user_id}},
+                        timeout=15,
+                    )
+                    res.raise_for_status()
+                    self.threads[user_id] = res.json().get("id")
+            except Exception as exc:  # pragma: no cover - network
+                # Сохраняем None, чтобы больше не пытаться создавать поток
+                self.threads[user_id] = None
+                # Логируем ошибку но не поднимаем её наверх
+                print(f"OpenAI thread creation failed: {exc}")
+        return self.threads.get(user_id)
 
     async def add_memory(self, user_id: str, content: str, role="user"):
         """Добавляет сообщение в Thread памяти"""
         tid = await self.get_or_create_thread(user_id)
+        if not tid:
+            return
         async with httpx.AsyncClient() as client:
-            await client.post(
-                f"https://api.openai.com/v1/threads/{tid}/messages",
-                headers=self.openai_h,
-                json={"role": role, "content": content}
-            )
+            try:
+                await client.post(
+                    f"https://api.openai.com/v1/threads/{tid}/messages",
+                    headers=self.openai_h,
+                    json={"role": role, "content": content},
+                    timeout=15,
+                )
+            except Exception as exc:  # pragma: no cover - network
+                print(f"OpenAI add_memory failed: {exc}")
 
     async def search_memory(self, user_id: str, query: str) -> str:
         """Выполняет поиск в памяти через GPT-4o mini Assistant"""
-        if not self.ASSISTANT_ID:
+        if not (self.ASSISTANT_ID and self.openai_key):
             return ""
 
         tid = await self.get_or_create_thread(user_id)
-        async with httpx.AsyncClient() as client:
-            # добавляем поисковый запрос
-            await client.post(
-                f"https://api.openai.com/v1/threads/{tid}/messages",
-                headers=self.openai_h,
-                json={"role": "user", "content": f"ПОИСК: {query}"}
-            )
-
-            # запускаем Assistant
-            run = await client.post(
-                f"https://api.openai.com/v1/threads/{tid}/runs",
-                headers=self.openai_h,
-                json={"assistant_id": self.ASSISTANT_ID}
-            )
-            run_id = run.json()["id"]
-
-            # ждём завершения
-            while True:
-                await asyncio.sleep(1)
-                st = await client.get(
-                    f"https://api.openai.com/v1/threads/{tid}/runs/{run_id}",
-                    headers=self.openai_h
-                )
-                if st.json()["status"] == "completed":
-                    break
-
-            # берём ответ
-            msgs = await client.get(
-                f"https://api.openai.com/v1/threads/{tid}/messages",
-                headers=self.openai_h,
-                params={"limit": 1}
-            )
-            data = msgs.json()["data"]
-            if data:
-                return data[0]["content"][0]["text"]["value"]
+        if not tid:
             return ""
+
+        async with httpx.AsyncClient() as client:
+            try:
+                # добавляем поисковый запрос
+                await client.post(
+                    f"https://api.openai.com/v1/threads/{tid}/messages",
+                    headers=self.openai_h,
+                    json={"role": "user", "content": f"ПОИСК: {query}"},
+                    timeout=15,
+                )
+
+                # запускаем Assistant
+                run = await client.post(
+                    f"https://api.openai.com/v1/threads/{tid}/runs",
+                    headers=self.openai_h,
+                    json={"assistant_id": self.ASSISTANT_ID},
+                    timeout=15,
+                )
+                run_id = run.json()["id"]
+
+                # ждём завершения
+                while True:
+                    await asyncio.sleep(1)
+                    st = await client.get(
+                        f"https://api.openai.com/v1/threads/{tid}/runs/{run_id}",
+                        headers=self.openai_h,
+                        timeout=15,
+                    )
+                    if st.json().get("status") == "completed":
+                        break
+
+                # берём ответ
+                msgs = await client.get(
+                    f"https://api.openai.com/v1/threads/{tid}/messages",
+                    headers=self.openai_h,
+                    params={"limit": 1},
+                    timeout=15,
+                )
+                data = msgs.json().get("data", [])
+                if data:
+                    return data[0]["content"][0]["text"]["value"]
+            except Exception as exc:  # pragma: no cover - network
+                print(f"OpenAI search_memory failed: {exc}")
+        return ""
 
     async def generate_with_xai(
         self, messages: list, context: str = ""


### PR DESCRIPTION
## Summary
- handle OpenAI thread failures gracefully to avoid crashing when memory backend is unavailable
- make `/when`, `/mars`, `/42`, and `/whatsnew` respond in the user's language with links preserved
- route Telegram command handlers with detected user language

## Testing
- `python -m py_compile utils/42.py utils/hybrid_engine.py server.py`
- `pytest` *(fails: PytestUnknownMarkWarning / async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca74ee7c8329bd6f3cfe3b5b3ded