### PR TITLE
Ensure async tests run by including pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow>=10.0.0
 openai>=1.0.0
 requests>=2.31.0
 beautifulsoup4>=4.12.0
+pytest-asyncio>=1.0.0


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` to requirements so async tests are supported

## Testing
- `pytest -q`
- `flake8` (fails: style errors across project)


------
https://chatgpt.com/codex/tasks/task_e_6890d94557d483299fdf5820a1d4637d