### PR TITLE
Verify webhook secret token

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,44 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET", "SECRET")
+    import server
+    importlib.reload(server)
+
+    async def dummy_feed_update(bot, update):
+        return None
+
+    monkeypatch.setattr(server.dp, "feed_update", dummy_feed_update)
+
+    class DummyUpdate:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(server.types, "Update", DummyUpdate)
+    return server.app
+
+
+def test_webhook_forbidden(app):
+    client = TestClient(app)
+    response = client.post(
+        "/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "WRONG"},
+        json={"update_id": 1},
+    )
+    assert response.status_code == 403
+
+
+def test_webhook_ok(app):
+    client = TestClient(app)
+    response = client.post(
+        "/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "SECRET"},
+        json={"update_id": 1},
+    )
+    assert response.status_code == 200
+    assert response.text == "OK"


### PR DESCRIPTION
## Summary
- check X-Telegram-Bot-Api-Secret-Token header against WEBHOOK_SECRET
- pass secret_token when setting webhook
- add tests for webhook secret handling

## Testing
- `ruff check server.py tests/test_webhook.py`
- `pytest tests/test_webhook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891606a3d90832982e85696beb677bc