### PR TITLE
Tighten exception handling across server and utils

### DIFF
--- a/SLNCX/scripts/fail_log.py
+++ b/SLNCX/scripts/fail_log.py
@@ -62,5 +62,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
     try:
         raise RuntimeError(args.message)
-    except Exception as e:
+    except RuntimeError as e:
         log_failure(args.prompt, e)

--- a/utils/howru.py
+++ b/utils/howru.py
@@ -40,7 +40,7 @@ async def send_prompt(text):
         reply = await engine.generate_with_xai([
             {"role": "user", "content": text}
         ])
-    except Exception as e:
+    except (RuntimeError, ValueError) as e:
         print(f"Ошибка xAI check_silence: {e}")
         reply = "🌀 Грокки: Что-то пошло не так"
     await engine.add_memory(OLEG_CHAT_ID, reply, role="assistant")

--- a/utils/repo_monitor.py
+++ b/utils/repo_monitor.py
@@ -27,5 +27,5 @@ async def monitor_repository(engine: VectorGrokkyEngine | None = None) -> None:
     try:
         await engine.add_memory("repo", message, role="journal")
         logger.info("Repo monitor recorded: %s", summary)
-    except Exception as exc:
+    except (RuntimeError, ValueError) as exc:
         logger.error("Failed to record repo snapshot: %s", exc)

--- a/utils/whatdotheythinkiam.py
+++ b/utils/whatdotheythinkiam.py
@@ -18,7 +18,7 @@ def _load_state():
     try:
         with open(STATE_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return {}
 
 
@@ -32,7 +32,7 @@ def _file_hash(path: str) -> str:
     try:
         with open(path, "rb") as f:
             return hashlib.md5(f.read()).hexdigest()
-    except Exception:
+    except OSError:
         return ""
 
 
@@ -42,7 +42,7 @@ def _load_vector_files() -> list[str]:
             data = json.load(f)
             if isinstance(data, dict):
                 return list(data.keys())
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         pass
     return []
 
@@ -75,7 +75,7 @@ def reflect_on_readme(force: bool = False) -> str:
     try:
         with open(README_PATH, "r", encoding="utf-8") as f:
             readme = f.read()
-    except Exception:
+    except OSError:
         pass
 
     readme_summary = _summarize(readme) if readme else ""
@@ -108,7 +108,7 @@ def latest_reflection() -> str:
     try:
         with open(THOUGHTS_PATH, "r", encoding="utf-8") as f:
             text = f.read().strip()
-    except Exception:
+    except OSError:
         return "No reflections yet."
 
     marker = "## Grokky Reflection"


### PR DESCRIPTION
## Summary
- Replace broad `except Exception` clauses with targeted exceptions in server initialization, HTTP helpers, and webhook processing
- Refine context processor extractors to catch library-specific errors like `PdfReadError`, `ParserError`, and `YAMLError`
- Narrow file and state handling exceptions in utility modules and scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68916440ee7883298aa90b83f191e299