### PR TITLE
Wrap file hash calculation in context manager

### DIFF
--- a/utils/context_neural_processor.py
+++ b/utils/context_neural_processor.py
@@ -722,7 +722,8 @@ async def parse_and_store_file(
     engine = engine or VectorGrokkyEngine()
 
     # Кэш и релевантность
-    file_hash = hashlib.sha256(open(path, "rb").read()).hexdigest()[:8]
+    with open(path, "rb") as f:
+        file_hash = hashlib.sha256(f.read()).hexdigest()[:8]
     cached = load_cache(path)
     relevance = compute_relevance(text)
     if cached and cached["hash"] == file_hash:


### PR DESCRIPTION
## Summary
- Compute file hash inside a `with open(..., 'rb')` block in `parse_and_store_file` to ensure the file is properly closed.

## Testing
- `flake8 utils/context_neural_processor.py` *(fails: F401 'aiohttp' imported but unused, line length and other style issues)*
- `pytest -q` *(fails: 14 failed, 10 passed, missing trio plugin and async support)*

------
https://chatgpt.com/codex/tasks/task_e_6891701a651c8329a4a4d4d78eab23b7