### PR TITLE
Fix missing message argument in chaos handler

### DIFF
--- a/server.py
+++ b/server.py
@@ -625,7 +625,8 @@ async def handle_text(message: Message, text: str) -> None:
         except (RuntimeError, ValueError) as e:
             logger.error("Ошибка CHAOS_PULSE: %s", e)
             await reply_split(
-                "🌀 Грокки: Даже хаос требует порядка. Ошибка при обработке команды."
+                message,
+                "🌀 Грокки: Даже хаос требует порядка. Ошибка при обработке команды.",
             )
         return
 


### PR DESCRIPTION
## Summary
- pass the message object to `reply_split` when chaos command handling fails

## Testing
- `ruff check server.py --select=E9,F63,F7,F82`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68916ff3eb908329b2a5e07c498c05a2