### PR TITLE
feat: add API key auth and rate limiting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ PyYAML==6.0.2
 rarfile==4.2
 fastapi==0.116.1
 uvicorn==0.35.0
+slowapi==0.1.9

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,31 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("API_KEY", "SECRET")
+    import server
+    importlib.reload(server)
+
+    async def dummy_handle(cmd):
+        return {"response": "ok", "pulse": 0}
+
+    monkeypatch.setattr(server, "handle", dummy_handle)
+    return server.app
+
+
+def test_api_key_required(app):
+    client = TestClient(app)
+    response = client.post("/42", json={"cmd": "42"})
+    assert response.status_code == 401
+
+
+def test_api_key_valid(app):
+    client = TestClient(app)
+    response = client.post(
+        "/42", headers={"X-API-Key": "SECRET"}, json={"cmd": "42"}
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- secure /42 and /file endpoints with header-based API key dependency
- add slowapi middleware for basic rate limiting
- test valid and invalid API key scenarios

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel: numpy 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_689178417080832994f3f53ea86dbf3f