### PR TITLE
chore: update httpx and drop requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 aiogram==3.0.0
 aiohttp==3.8.5
 python-dotenv==1.0.0
-httpx==0.23.0
+httpx>=0.27
 pinecone==2.2.4
 numpy==1.24.0
 pypdf==3.10.0
 pillow==10.0.0
 openai==1.0.0
-requests==2.31.0
 beautifulsoup4==4.12.0
 pytest-asyncio==1.0.0
 trio==0.22.0

--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -3,7 +3,7 @@ import time
 import math
 from typing import Optional, Sequence, List
 
-import requests
+import httpx
 
 
 def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
@@ -12,7 +12,7 @@ def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     payload = {"prompt": prompt, "max_tokens": 500}
     try:
-        res = requests.post(
+        res = httpx.post(
             "https://api.xai.org/grok-3/generate", json=payload, headers=headers
         )
         res.raise_for_status()
@@ -39,7 +39,7 @@ def query_gpt4(prompt: str, api_key: Optional[str] = None, model: str = "gpt-4o"
         "temperature": 0.8,
     }
     try:
-        res = requests.post(
+        res = httpx.post(
             "https://api.openai.com/v1/chat/completions",
             json=payload,
             headers=headers,


### PR DESCRIPTION
## Summary
- upgrade httpx dependency to >=0.27 and remove requests
- switch dynamic weight helper to httpx for API calls

## Testing
- `ruff check utils/dynamic_weights.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', 'PIL', 'aiohttp', 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6891782604988329ab715fcc75e126a8