### PR TITLE
feat: limit webhook payload size

### DIFF
--- a/server.py
+++ b/server.py
@@ -101,6 +101,7 @@ BANNED_DOMAINS = {
     for d in os.getenv("BANNED_DOMAINS", "").split(",")
     if d.strip()
 }
+MAX_WEBHOOK_BODY_SIZE = int(os.getenv("MAX_WEBHOOK_BODY_SIZE", "100000"))
 
 # Проверка ключей API
 XAI_API_KEY = os.getenv("XAI_API_KEY")
@@ -805,6 +806,13 @@ async def handle_webhook(request: Request):
             return PlainTextResponse(status_code=403, content="forbidden")
 
         request_body = await request.body()
+        if len(request_body) > MAX_WEBHOOK_BODY_SIZE:
+            logger.warning(
+                "Вебхук отклонен: размер %d байт превышает лимит %d",
+                len(request_body),
+                MAX_WEBHOOK_BODY_SIZE,
+            )
+            return PlainTextResponse(status_code=413, content="payload too large")
         logger.info(f"Получены данные вебхука длиной {len(request_body)} байт")
         data = json.loads(request_body)
         logger.info(f"Получено обновление от Telegram: {data.get('update_id')}")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,4 +1,6 @@
 import importlib
+import sys
+import types
 
 import pytest
 from fastapi.testclient import TestClient
@@ -7,6 +9,98 @@ from fastapi.testclient import TestClient
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("WEBHOOK_SECRET", "SECRET")
+    monkeypatch.setenv("MAX_WEBHOOK_BODY_SIZE", "50")
+    utils_pkg = types.ModuleType("utils")
+    utils_pkg.__path__ = []  # mark as package
+    sys.modules["utils"] = utils_pkg
+
+    def add_utils_submodule(name, attrs):
+        mod = types.ModuleType(f"utils.{name}")
+        for key, value in attrs.items():
+            setattr(mod, key, value)
+        sys.modules[f"utils.{name}"] = mod
+        setattr(utils_pkg, name, mod)
+
+    add_utils_submodule("dayandnight", {"day_and_night_task": lambda *a, **k: None})
+    add_utils_submodule(
+        "howru",
+        {
+            "check_silence": lambda *a, **k: None,
+            "update_last_message_time": lambda *a, **k: None,
+        },
+    )
+    add_utils_submodule("mirror", {"mirror_task": lambda *a, **k: None})
+    add_utils_submodule("prompt", {"get_chaos_response": lambda *a, **k: None})
+    add_utils_submodule("repo_monitor", {"monitor_repository": lambda *a, **k: None})
+    add_utils_submodule("imagine", {"imagine": lambda *a, **k: None})
+    add_utils_submodule("vision", {"analyze_image": lambda *a, **k: None})
+    add_utils_submodule("coder", {"interpret_code": lambda *a, **k: None})
+    add_utils_submodule(
+        "context_neural_processor",
+        {"parse_and_store_file": lambda *a, **k: None},
+    )
+    add_utils_submodule("vector_engine", {"VectorGrokkyEngine": type("VectorGrokkyEngine", (), {})})
+    add_utils_submodule("hybrid_engine", {"HybridGrokkyEngine": type("HybridGrokkyEngine", (), {})})
+
+    aiogram_pkg = types.ModuleType("aiogram")
+    aiogram_pkg.__path__ = []
+    aiogram_pkg.Bot = type(
+        "Bot",
+        (),
+        {
+            "__init__": lambda self, *a, **k: None,
+            "send_message": lambda *a, **k: None,
+            "get_file": lambda *a, **k: None,
+        },
+    )
+
+    class Dispatcher:
+        def __init__(self, *a, **k):
+            pass
+
+        def message(self, *a, **k):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def callback_query(self, *a, **k):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        async def feed_update(self, *a, **k):
+            return None
+
+    aiogram_pkg.Dispatcher = Dispatcher
+    sys.modules["aiogram"] = aiogram_pkg
+    sys.modules["aiogram.types"] = types.SimpleNamespace(
+        Message=type("Message", (), {"reply": lambda self, *a, **k: None}),
+        CallbackQuery=type("CallbackQuery", (), {"data": ""}),
+    )
+    sys.modules["aiogram.enums"] = types.SimpleNamespace(
+        ChatAction=type("ChatAction", (), {})
+    )
+    sys.modules["aiogram.filters"] = types.SimpleNamespace(
+        Command=type("Command", (), {"__init__": lambda self, *a, **k: None})
+    )
+    sys.modules["aiogram.exceptions"] = types.SimpleNamespace(
+        TelegramAPIError=Exception
+    )
+    sub_module_42 = types.ModuleType("utils.42")
+    sub_module_42.handle = lambda *a, **k: None
+    sys.modules["utils.42"] = sub_module_42
+    utils_pkg.handle = sub_module_42.handle
+
+    sl_pkg = types.ModuleType("SLNCX")
+    sl_pkg.__path__ = []
+    sys.modules["SLNCX"] = sl_pkg
+    wi_module = types.ModuleType("SLNCX.wulf_integration")
+    wi_module.generate_response = lambda *a, **k: None
+    sys.modules["SLNCX.wulf_integration"] = wi_module
+    setattr(sl_pkg, "wulf_integration", wi_module)
+
     import server
     importlib.reload(server)
 
@@ -19,7 +113,7 @@ def app(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
-    monkeypatch.setattr(server.types, "Update", DummyUpdate)
+    monkeypatch.setattr(server.types, "Update", DummyUpdate, raising=False)
     return server.app
 
 
@@ -42,3 +136,14 @@ def test_webhook_ok(app):
     )
     assert response.status_code == 200
     assert response.text == "OK"
+
+
+def test_webhook_payload_too_large(app):
+    client = TestClient(app)
+    response = client.post(
+        "/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "SECRET"},
+        json={"update_id": 1, "text": "x" * 100},
+    )
+    assert response.status_code == 413
+    assert response.text == "payload too large"


### PR DESCRIPTION
## Summary
- cap webhook requests with MAX_WEBHOOK_BODY_SIZE
- reject webhook requests exceeding configured limit
- cover webhook handler with oversized payload test

## Testing
- `flake8 server.py tests/test_webhook.py --ignore=E501,E203,F841,W503`
- `pytest tests/test_webhook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68917811f6048329ad727fc56af1ee0e