### PR TITLE
Fix build failure by updating numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp==3.8.5
 python-dotenv==1.0.0
 httpx>=0.27
 pinecone==2.2.4
-numpy==1.24.0
+numpy==1.26.4
 pypdf==3.10.0
 pillow==10.0.0
 openai==1.0.0


### PR DESCRIPTION
## Summary
- update numpy pin to 1.26.4 to provide a wheel compatible with Python 3.12 and avoid build backend errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6891829399548329a75dfbc7916535b9