### PR TITLE
Pin httpx below v0.28 to restore OpenAI compatibility

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -398,9 +398,9 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
-httpx==0.28.1 \
-    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
-    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+httpx==0.27.2 \
+    --hash=sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0 \
+    --hash=sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2
     # via
     #   -r requirements.txt
     #   openai

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiogram==3.21.0
 aiohttp==3.12.15
 python-dotenv==1.0.0
-httpx>=0.27
+httpx>=0.27,<0.28
 pinecone==2.2.4
 numpy==1.26.4
 pypdf==3.10.0


### PR DESCRIPTION
## Summary
- pin httpx<0.28 to avoid `Client.__init__ got an unexpected keyword argument 'proxies'`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918f8cda548329b7e994def58b7b2e