### PR TITLE
fix: add python-multipart dependency

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1056,6 +1056,10 @@ python-dotenv==1.0.0 \
     --hash=sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba \
     --hash=sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a
     # via -r requirements.txt
+python-multipart==0.0.20 \
+    --hash=sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104 \
+    --hash=sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13
+    # via -r requirements.txt
 python-pptx==1.0.2 \
     --hash=sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba \
     --hash=sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095
@@ -1145,6 +1149,7 @@ sniffio==1.3.1 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
     # via
     #   anyio
+    #   httpx
     #   trio
 sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ rarfile==4.2
 fastapi==0.116.1
 uvicorn==0.35.0
 slowapi==0.1.9
+python-multipart==0.0.20


### PR DESCRIPTION
## Summary
- include python-multipart to support FastAPI form parsing
- regenerate dependency lock file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891b64381e483298ce0f59fa74b205d