### PR TITLE
Improve network robustness with timeouts and thread offloading

### DIFF
--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -13,7 +13,10 @@ def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
     payload = {"prompt": prompt, "max_tokens": 500}
     try:
         res = httpx.post(
-            "https://api.xai.org/grok-3/generate", json=payload, headers=headers
+            "https://api.xai.org/grok-3/generate",
+            json=payload,
+            headers=headers,
+            timeout=30,
         )
         res.raise_for_status()
         return res.json().get("text", "")

--- a/utils/vector_engine.py
+++ b/utils/vector_engine.py
@@ -3,6 +3,7 @@ import httpx
 import traceback
 import logging
 import time
+import asyncio
 from datetime import datetime
 import hashlib
 import numpy as np
@@ -169,8 +170,10 @@ class VectorGrokkyEngine:
             # Уникальный ID для записи
             record_id = f"{user_id}_{role}_{int(time.time()*1000)}"
 
-            # Сохраняем в Pinecone
-            self.index.upsert(vectors=[(record_id, embedding, metadata)])
+            # Сохраняем в Pinecone в отдельном потоке, чтобы не блокировать event loop
+            await asyncio.to_thread(
+                self.index.upsert, vectors=[(record_id, embedding, metadata)]
+            )
 
             logger.info(
                 f"Добавлена запись в память: user={user_id}, role={role}, id={record_id}"


### PR DESCRIPTION
## Summary
- add 30s timeout to Grok-3 API calls
- run Pinecone upsert in a background thread to avoid blocking the event loop

## Testing
- `python -m flake8 --max-line-length=120 utils/dynamic_weights.py utils/vector_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689240826f6c8329b82e68f8c2ceea34