### PR TITLE
feat: integrate dynamic weights into SLNCX

### DIFF
--- a/SLNCX/wulf_integration.py
+++ b/SLNCX/wulf_integration.py
@@ -3,7 +3,7 @@ import json
 import time
 from typing import Optional, Any
 
-from utils.dynamic_weights import get_dynamic_knowledge
+from utils.dynamic_weights import DynamicWeights, get_dynamic_knowledge
 
 # System prompt for Wulf mode
 WULF_PROMPT = (
@@ -59,6 +59,10 @@ def generate_response(
         full_prompt = WULF_PROMPT + "\nUser: " + prompt
         raw_response = get_dynamic_knowledge(full_prompt, api_key)
         response = _extract_text(raw_response)
+
+        # Derive dynamic weights for logging/experimentation.
+        dw = DynamicWeights()
+        log_entry["weights"] = dw.weights_for_prompt(full_prompt, api_key)
         log_entry["response"] = response
         os.makedirs("logs/wulf", exist_ok=True)
         with open(


### PR DESCRIPTION
## Summary
- add `DynamicWeights` helper for pulse-based weight scaling
- expose `apply_dynamic_weights` to scale SLNCX parameters from prompt context
- log computed dynamic weights during Wulf-mode generation

## Testing
- `ruff utils/dynamic_weights.py SLNCX/model.py SLNCX/wulf_integration.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892efba2ab883298e361e8a9f72e515