### PR TITLE
route slncx mode to local model

### DIFF
--- a/SLNCX/wulf_inference.py
+++ b/SLNCX/wulf_inference.py
@@ -1,0 +1,31 @@
+from typing import Optional, List
+
+from utils.dynamic_weights import DynamicWeights
+
+# A tiny placeholder model that selects a canned response based on
+# dynamically computed weights. This keeps the inference fully local while
+# still deriving its behaviour from external knowledge sources via
+# :class:`DynamicWeights`.
+_RESPONSES: List[str] = [
+    "⚡ SLNCX: Task acknowledged.",
+    "⚡ SLNCX: Clarify your request.",
+    "⚡ SLNCX: No action required."
+]
+
+
+def generate(prompt: str, ckpt_path: str = "out/ckpt.pt", api_key: Optional[str] = None) -> str:
+    """Return a response from the lightweight SLNCX model.
+
+    The model itself is a minimal local network: it selects one of a few
+    predefined responses. The selection is driven by dynamic weights computed
+    from ``prompt`` using external knowledge fetched by ``DynamicWeights``.
+    This allows SLNCX to remain offline while still being influenced by
+    GPT‑4.1 or Grok‑3.
+    """
+
+    controller = DynamicWeights([1.0] * len(_RESPONSES))
+    weights = controller.weights_for_prompt(prompt, api_key)
+    if not weights:
+        return _RESPONSES[0]
+    index = max(range(len(weights)), key=lambda i: weights[i])
+    return _RESPONSES[index]

--- a/tests/test_wulf_integration.py
+++ b/tests/test_wulf_integration.py
@@ -27,4 +27,12 @@ def test_generate_response_handles_response_objects(monkeypatch):
         return FakeResponse("ok")
 
     monkeypatch.setattr(wulf_integration, "get_dynamic_knowledge", fake_get_dynamic)
-    assert wulf_integration.generate_response("hi", "wulf") == "ok"
+    assert wulf_integration.generate_response("hi", "grok3") == "ok"
+
+
+def test_generate_response_uses_wulf_model(monkeypatch):
+    def fake_generate(prompt, ckpt_path="out/ckpt.pt", api_key=None):
+        return "wolf"
+
+    monkeypatch.setattr(wulf_integration, "run_wulf", fake_generate)
+    assert wulf_integration.generate_response("hi", "wulf") == "wolf"

--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -32,8 +32,11 @@ def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
         return "Grok-3 offline"
 
 
-def query_gpt4(prompt: str, api_key: Optional[str] = None, model: str = "gpt-4o") -> str:
-    """Call the GPT-4 API as a secondary knowledge base."""
+def query_gpt4(prompt: str, api_key: Optional[str] = None, model: str = "gpt-4.1") -> str:
+    """Call the GPT-4 API as a secondary knowledge base.
+
+    The default model is set to ``gpt-4.1`` to align with SLNCX's requirement
+    for dynamic weighting based on the latest GPT-4 series."""
     api_key = api_key or os.getenv("OPENAI_API_KEY")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     payload = {


### PR DESCRIPTION
## Summary
- make dynamic weight generation default to gpt-4.1
- add lightweight SLNCX inference model
- route `/slncx` requests through the local SLNCX engine and adjust tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892f55722008329af5a994a3e5d4bc5