### PR TITLE
Implement async streaming for Wulf responses

### DIFF
--- a/SLNCX/wulf_cli.py
+++ b/SLNCX/wulf_cli.py
@@ -1,14 +1,19 @@
 import argparse
+import asyncio
+
 from .wulf_integration import generate_response
 
 
-def main() -> None:
+async def main() -> None:
     parser = argparse.ArgumentParser(description="Wulf CLI")
     parser.add_argument("prompt", help="prompt text")
     parser.add_argument("--mode", default="grok3", choices=["grok3", "wulf"])
     args = parser.parse_args()
-    print(generate_response(args.prompt, mode=args.mode))
+
+    async for token in generate_response(args.prompt, mode=args.mode):
+        print(token, end="", flush=True)
+    print()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,63 @@
+import pytest
+from types import SimpleNamespace
+
+from SLNCX import wulf_inference
+import server
+
+
+@pytest.mark.anyio
+async def test_wulf_inference_streams_tokens():
+    gen = wulf_inference.generate("hello")
+    tokens = []
+    async for t in gen:
+        tokens.append(t)
+    # Expect tokens join to one of predefined responses
+    assert "".join(tokens).strip().startswith("⚡ SLNCX")
+
+
+class DummyBot:
+    def __init__(self):
+        self.actions = []
+        self.edits = []
+
+    async def send_chat_action(self, chat_id, action):
+        self.actions.append((chat_id, action))
+
+    async def edit_message_text(self, text, chat_id, message_id):
+        self.edits.append(text)
+
+    async def send_message(self, chat_id, text):
+        self.sent = text
+        return SimpleNamespace(message_id=1)
+
+    async def get_file(self, *a, **k):
+        return None
+
+
+class DummyMessage:
+    def __init__(self):
+        self.chat = SimpleNamespace(id=1)
+        self.replied = []
+
+    async def reply(self, text):
+        self.replied.append(text)
+        return SimpleNamespace(message_id=1)
+
+
+@pytest.mark.anyio
+async def test_server_streams_to_bot(monkeypatch):
+    async def fake_generate(prompt, mode):
+        for tok in ["foo ", "bar"]:
+            yield tok
+
+    monkeypatch.setattr(server, "generate_response", fake_generate)
+    dummy_bot = DummyBot()
+    monkeypatch.setattr(server, "bot", dummy_bot)
+    monkeypatch.setattr(server, "ChatAction", SimpleNamespace(TYPING="typing"))
+    msg = DummyMessage()
+
+    await server.stream_wulf_response(msg, "hi")
+
+    assert msg.replied == ["foo "]
+    assert dummy_bot.edits == ["foo bar"]
+    assert dummy_bot.actions  # typing actions sent

--- a/tests/test_wulf_integration.py
+++ b/tests/test_wulf_integration.py
@@ -5,6 +5,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from SLNCX import wulf_integration
 
+import pytest  # noqa: E402
+
 
 class FakePiece:
     def __init__(self, text):
@@ -22,17 +24,23 @@ class FakeResponse:
         self.output = [FakeMessage(text)]
 
 
-def test_generate_response_handles_response_objects(monkeypatch):
+@pytest.mark.anyio
+async def test_generate_response_handles_response_objects(monkeypatch):
     def fake_get_dynamic(prompt, api_key=None):
         return FakeResponse("ok")
 
     monkeypatch.setattr(wulf_integration, "get_dynamic_knowledge", fake_get_dynamic)
-    assert wulf_integration.generate_response("hi", "grok3") == "ok"
-
-
-def test_generate_response_uses_wulf_model(monkeypatch):
-    def fake_generate(prompt, ckpt_path="out/ckpt.pt", api_key=None):
-        return "wolf"
+    result = []
+    async for token in wulf_integration.generate_response("hi", "grok3"):
+        result.append(token)
+    assert "".join(result) == "ok"
+@pytest.mark.anyio
+async def test_generate_response_uses_wulf_model(monkeypatch):
+    async def fake_generate(prompt, ckpt_path="out/ckpt.pt", api_key=None):
+        yield "wolf"
 
     monkeypatch.setattr(wulf_integration, "run_wulf", fake_generate)
-    assert wulf_integration.generate_response("hi", "wulf") == "wolf"
+    result = []
+    async for token in wulf_integration.generate_response("hi", "wulf"):
+        result.append(token)
+    assert "".join(result).strip() == "wolf"

--- a/tests/test_wulf_language.py
+++ b/tests/test_wulf_language.py
@@ -6,12 +6,18 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from SLNCX import wulf_inference
 from utils.dynamic_weights import DynamicWeights
 
+import pytest
 
-def test_generate_russian_response(monkeypatch):
+
+@pytest.mark.anyio
+async def test_generate_russian_response(monkeypatch):
     def fake_weights(self, prompt, api_key=None):
         return [1.0] + [0.0] * 4
 
     monkeypatch.setattr(DynamicWeights, "weights_for_prompt", fake_weights)
-    response = wulf_inference.generate("привет")
+    tokens = []
+    async for t in wulf_inference.generate("привет"):
+        tokens.append(t)
+    response = "".join(tokens)
     assert "Задача" in response
 


### PR DESCRIPTION
## Summary
- stream Wulf model replies via async generators
- proxy streamed tokens to Telegram using typing actions
- test streaming behavior and async integration

## Testing
- `ruff SLNCX/wulf_inference.py SLNCX/wulf_integration.py SLNCX/wulf_cli.py server.py tests/test_wulf_integration.py tests/test_streaming.py tests/test_wulf_language.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893af97b9548329a97fd1499f6ebb36