### PR TITLE
feat: add multilingual support

### DIFF
--- a/server.py
+++ b/server.py
@@ -175,6 +175,12 @@ def detect_language(text: str) -> str:
     """Very small heuristic language detector."""
     if re.search("[а-яА-Я]", text):
         return "ru"
+    if re.search("[äöüßÄÖÜ]", text):
+        return "de"
+    if re.search("[ñáéíóúÑÁÉÍÓÚ]", text):
+        return "es"
+    if re.search("[éàèùâêîôûçœÉÀÈÙÂÊÎÔÛÇŒ]", text):
+        return "fr"
     if re.search("[a-zA-Z]", text):
         return "en"
     return "en"
@@ -185,10 +191,18 @@ async def synth_voice(text: str, lang: str = "ru") -> bytes:
     if not OPENAI_API_KEY:
         return b""
 
+    voice_map = {
+        "ru": "onyx",
+        "en": "alloy",
+        "es": "coral",
+        "de": "marco",
+        "fr": "fable",
+    }
+
     payload = {
         "model": "tts-1",
         "input": text,
-        "voice": "onyx",
+        "voice": voice_map.get(lang, "alloy"),
     }
     headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
 
@@ -372,7 +386,7 @@ async def cmd_status(message: Message):
             stats = engine.index.describe_index_stats()
             total_vectors = stats.get("total_vector_count", 0)
             status_text += f"Векторов в памяти: {total_vectors}"
-        except (RuntimeError, ValueError) as e:
+        except (RuntimeError, ValueError):
             status_text += "Ошибка при получении статистики памяти"
 
     await reply_split(message, status_text)

--- a/tests/test_wulf_language.py
+++ b/tests/test_wulf_language.py
@@ -5,6 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from SLNCX import wulf_inference  # noqa: E402
 from utils.dynamic_weights import DynamicWeights  # noqa: E402
+from server import detect_language  # noqa: E402
 
 
 def test_generate_russian_response(monkeypatch):
@@ -14,3 +15,15 @@ def test_generate_russian_response(monkeypatch):
     monkeypatch.setattr(DynamicWeights, "generate_response", fake_generate)
     response = wulf_inference.generate("привет")
     assert response == "ответ"
+
+
+def test_detect_spanish():
+    assert detect_language("hola señor") == "es"
+
+
+def test_detect_german():
+    assert detect_language("straße für") == "de"
+
+
+def test_detect_french():
+    assert detect_language("où est l'hôtel") == "fr"

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -1,0 +1,30 @@
+"""Utility for translating text via OpenAI."""
+from __future__ import annotations
+
+import logging
+import os
+
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def translate(text: str, target_lang: str) -> str:
+    """Translate ``text`` into ``target_lang`` using OpenAI."""
+    prompt = f"Translate the following text to {target_lang}: {text}"
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a translation assistant."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.choices[0].message.content.strip()
+    except Exception as exc:  # pragma: no cover - network
+        logger.error("Translation error: %s", exc)
+        return text
+
+
+__all__ = ["translate"]


### PR DESCRIPTION
## Summary
- expand language detector with Spanish, German, and French
- add OpenAI-based translation utility
- select TTS voice per language
- test language detection for ES/DE/FR

## Testing
- `ruff server.py utils/translation.py tests/test_wulf_language.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ba1162bc8329b82c4f24939b672d