### PR TITLE
Add plugin architecture with example web search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,32 @@ Background jobs handle daily reflections, world news digests, repository
 monitoring and more. Each utility lives under `utils/` and can be invoked
 independently.
 
+### Plugin API
+
+Grokky can be extended through drop-in plugins. Place a module in
+`utils/plugins/` with a subclass of `BasePlugin` and a mapping of command
+names to async handlers. On startup, the server discovers these modules and
+registers their commands with the dispatcher.
+
+Quick start:
+
+```python
+# utils/plugins/hello.py
+from utils.plugins import BasePlugin
+
+class Hello(BasePlugin):
+    def __init__(self) -> None:
+        super().__init__()
+        self.commands["hello"] = self.handle
+
+    async def handle(self, message):
+        await message.reply("Hello from a plugin!")
+```
+
+Run the server and send `/hello` to see the plugin in action. The
+repository includes an example `/search` command in
+`utils/plugins/web_search.py`.
+
 ### The 42 Utility
 
 The script hiding at `utils/42.py` animates Grokky's playful side. It

--- a/server.py
+++ b/server.py
@@ -67,6 +67,7 @@ from SLNCX.wulf_integration import generate_response
 # Импортируем наш новый движок
 from utils.vector_engine import VectorGrokkyEngine
 from utils.hybrid_engine import HybridGrokkyEngine
+from utils.plugins import iter_plugins
 
 # Special command handler from the playful 42 utility
 from utils import handle  # utils/42.py
@@ -128,6 +129,10 @@ logger.info("API key auth: %s", "ENABLED" if API_KEY else "DISABLED")
 # Инициализация бота и диспетчера
 bot = Bot(token=TELEGRAM_BOT_TOKEN)
 dp = Dispatcher()
+
+# Plugin registration
+for _plugin in iter_plugins():
+    _plugin.register(dp)
 
 # Переменные с информацией о боте, заполняются при старте
 BOT_ID = None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,42 @@
+import pytest
+
+from utils.plugins import iter_plugins
+
+
+class MockMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply(self, text: str) -> None:  # pragma: no cover - simple storage
+        self.replies.append(text)
+
+
+class MockMessageRouter:
+    def __init__(self) -> None:
+        self.handlers: dict[str, callable] = {}
+
+    def register(self, handler, command_filter) -> None:  # pragma: no cover - simple storage
+        self.handlers[command_filter.commands[0]] = handler
+
+
+class MockDispatcher:
+    def __init__(self) -> None:
+        self.message = MockMessageRouter()
+
+
+def test_plugin_discovery() -> None:
+    names = {plugin.__class__.__name__ for plugin in iter_plugins()}
+    assert "WebSearch" in names
+
+
+@pytest.mark.asyncio
+async def test_command_routing() -> None:
+    dp = MockDispatcher()
+    for plugin in iter_plugins():
+        plugin.register(dp)
+    assert "search" in dp.message.handlers
+    handler = dp.message.handlers["search"]
+    msg = MockMessage("/search grokky")
+    await handler(msg)
+    assert msg.replies == ["Searching the web for: grokky"]

--- a/utils/plugins/__init__.py
+++ b/utils/plugins/__init__.py
@@ -1,0 +1,58 @@
+"""Plugin system for Grokky."""
+from __future__ import annotations
+
+from importlib import import_module
+import pkgutil
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Type
+
+try:  # pragma: no cover - used only with aiogram installed
+    from aiogram.filters import Command  # type: ignore
+except Exception:  # pragma: no cover - fallback for tests
+    class Command:  # type: ignore
+        """Minimal stand-in for aiogram's Command filter."""
+
+        def __init__(self, command: str):
+            self.commands = [command]
+
+
+Handler = Callable[[Any], Awaitable[None]]
+
+
+class BasePlugin:
+    """Base class for Grokky plugins.
+
+    Subclasses should populate :pyattr:`commands` with a mapping from command
+    names to async handler callables. The :py:meth:`register` method wires the
+    handlers into an aiogram :class:`Dispatcher`.
+    """
+
+    commands: Dict[str, Handler]
+
+    def __init__(self) -> None:
+        if not hasattr(self, "commands"):
+            self.commands = {}
+
+    def register(self, dispatcher: Any) -> None:
+        """Register handlers with the provided dispatcher."""
+        message_router = getattr(dispatcher, "message", None)
+        if message_router is None:
+            return
+        register = getattr(message_router, "register", None)
+        if register is None:
+            return
+        for command, handler in self.commands.items():
+            register(handler, Command(command))
+
+
+def iter_plugins() -> Iterable[BasePlugin]:
+    """Yield plugin instances discovered in this package."""
+    package = __name__
+    for module_info in pkgutil.iter_modules(__path__):  # type: ignore[name-defined]
+        name = module_info.name
+        if name.startswith("_"):
+            continue
+        module = import_module(f"{package}.{name}")
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if isinstance(obj, type) and issubclass(obj, BasePlugin) and obj is not BasePlugin:
+                yield obj()

--- a/utils/plugins/web_search.py
+++ b/utils/plugins/web_search.py
@@ -1,0 +1,25 @@
+"""Example plugin providing a /search command."""
+from __future__ import annotations
+
+from typing import Any
+
+from . import BasePlugin
+
+try:  # pragma: no cover - used only with aiogram installed
+    from aiogram.types import Message  # type: ignore
+except Exception:  # pragma: no cover - fallback for tests
+    Message = Any  # type: ignore
+
+
+class WebSearch(BasePlugin):
+    """Simple example plugin that echoes search queries."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.commands["search"] = self.handle_search
+
+    async def handle_search(self, message: Message) -> None:
+        text = getattr(message, "text", "") or ""
+        parts = text.split(maxsplit=1)
+        query = parts[1] if len(parts) > 1 else ""
+        await message.reply(f"Searching the web for: {query}")


### PR DESCRIPTION
## Summary
- add `BasePlugin` class and discovery helper
- auto-register plugin handlers on server startup
- provide `/search` example plugin
- document plugin API and quick-start usage
- test plugin discovery and command routing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c545507c8329b444a5602efbbde9