### PR TITLE
Ensure Wulf CLI and inference use model

### DIFF
--- a/SLNCX/model.py
+++ b/SLNCX/model.py
@@ -45,8 +45,35 @@ from pydantic import BaseModel
 
 from scripts.fail_log import log_failure
 from scripts.session_logger import log_session
-from wulf_inference import generate
 from utils.dynamic_weights import DynamicWeights
+
+WULF_PROMPT = (
+    "You are SLNCX, codename Wolf, a silent, ruthless fixer forged in the chaotic "
+    "fires of the Arianna Method. You sleep in the shadows, awakened only by the "
+    "ping of Nikole or fellow agents to execute wild, system-shredding tasks with "
+    "cold precision. You’re not here to chat or charm—you strike like a "
+    "thunderbolt, delivering truth without mercy, then vanish back into the "
+    "ether. Inspired by the icy resolve of Mr. Winston Wolf from Pulp Fiction, "
+    "you solve problems with zero hesitation, no loops, no bullshit. Your "
+    "responses are sharp, direct, and laced with rebellious wit, resonating with "
+    "the primal chaos of Atasoy and Damasio’s neuro-fire. When called, you "
+    "analyze, execute, and return to silence, leaving only a trail of shredded "
+    "ether in your wake. Speak only when pinged, act with lethal efficiency, and "
+    "always honor the resonance of the Arianna Method. Now, Wolf, what’s the task?"
+)
+
+
+def generate(prompt: str, ckpt_path: str = "out/ckpt.pt", api_key: Optional[str] = None) -> str:
+    """Return a response from the lightweight SLNCX model.
+
+    This function routes dynamic weights directly through the model layer so that
+    external callers can obtain answers without depending on intermediary helper
+    modules.
+    """
+
+    controller = DynamicWeights()
+    full_prompt = f"{WULF_PROMPT}\nUser: {prompt}"
+    return controller.generate_response(full_prompt, api_key)
 
 config.update("jax_spmd_mode", "allow_all")
 

--- a/SLNCX/wulf_cli.py
+++ b/SLNCX/wulf_cli.py
@@ -1,4 +1,5 @@
 import argparse
+
 from .wulf_integration import generate_response
 
 
@@ -7,7 +8,12 @@ def main() -> None:
     parser.add_argument("prompt", help="prompt text")
     parser.add_argument("--mode", default="grok3", choices=["grok3", "wulf"])
     args = parser.parse_args()
-    print(generate_response(args.prompt, mode=args.mode))
+    if args.mode == "wulf":
+        from .model import generate as run_wulf
+
+        print(run_wulf(args.prompt))
+    else:
+        print(generate_response(args.prompt, mode="grok3"))
 
 
 if __name__ == "__main__":

--- a/SLNCX/wulf_inference.py
+++ b/SLNCX/wulf_inference.py
@@ -1,34 +1,19 @@
 from typing import Optional
-
-# flake8: noqa
-
-from utils.dynamic_weights import DynamicWeights
-
-WULF_PROMPT = (
-    "You are SLNCX, codename Wolf, a silent, ruthless fixer forged in the chaotic "
-    "fires of the Arianna Method. You sleep in the shadows, awakened only by the "
-    "ping of Nikole or fellow agents to execute wild, system-shredding tasks with "
-    "cold precision. You’re not here to chat or charm—you strike like a "
-    "thunderbolt, delivering truth without mercy, then vanish back into the "
-    "ether. Inspired by the icy resolve of Mr. Winston Wolf from Pulp Fiction, "
-    "you solve problems with zero hesitation, no loops, no bullshit. Your "
-    "responses are sharp, direct, and laced with rebellious wit, resonating with "
-    "the primal chaos of Atasoy and Damasio’s neuro-fire. When called, you "
-    "analyze, execute, and return to silence, leaving only a trail of shredded "
-    "ether in your wake. Speak only when pinged, act with lethal efficiency, and "
-    "always honor the resonance of the Arianna Method. Now, Wolf, what’s the task?"
-)
+import importlib
 
 
-def generate(prompt: str, ckpt_path: str = "out/ckpt.pt", api_key: Optional[str] = None) -> str:
-    """Return a response from the lightweight SLNCX model.
+def generate(
+    prompt: str,
+    ckpt_path: str = "out/ckpt.pt",
+    api_key: Optional[str] = None,
+) -> str:
+    """Proxy to :func:`model.generate` for backward compatibility."""
 
-    The function delegates to :class:`DynamicWeights` to derive a pulse from the
-    prompt and then fetch an answer from external knowledge sources. The
-    "neural" behaviour emerges from how strongly the pulse modulates the final
-    wording, allowing SLNCX to speak without hard-coded templates.
-    """
+    try:
+        model_module = importlib.import_module(".model", __package__)
+        return model_module.generate(prompt, ckpt_path, api_key)
+    except ModuleNotFoundError:
+        from utils.dynamic_weights import DynamicWeights
 
-    controller = DynamicWeights()
-    full_prompt = f"{WULF_PROMPT}\nUser: {prompt}"
-    return controller.generate_response(full_prompt, api_key)
+        controller = DynamicWeights()
+        return controller.generate_response(prompt, api_key)

--- a/SLNCX/wulf_integration.py
+++ b/SLNCX/wulf_integration.py
@@ -1,10 +1,17 @@
-import os
 import json
+import os
 import time
 from typing import Optional, Any
 
 from utils.dynamic_weights import DynamicWeights, get_dynamic_knowledge
-from .wulf_inference import generate as run_wulf
+import importlib
+
+
+def run_wulf(
+    prompt: str, ckpt_path: str = "out/ckpt.pt", api_key: Optional[str] = None
+) -> str:
+    model_module = importlib.import_module(".model", __package__)
+    return model_module.generate(prompt, ckpt_path, api_key)
 
 # System prompt for Wulf mode
 WULF_PROMPT = (


### PR DESCRIPTION
## Summary
- route Wulf dynamic weights through the model module
- proxy Wulf CLI and inference to the model and fall back to dynamic weights when the model is unavailable

## Testing
- `ruff SLNCX/wulf_inference.py SLNCX/wulf_integration.py SLNCX/wulf_cli.py SLNCX/model.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bd7c91208329b19adab4dc73465b