### PR TITLE
Improve error logging for OpenAI memory and world updates

### DIFF
--- a/utils/hybrid_engine.py
+++ b/utils/hybrid_engine.py
@@ -1,6 +1,10 @@
 import os
 import asyncio
+import logging
 import httpx
+
+
+logger = logging.getLogger(__name__)
 
 
 class HybridGrokkyEngine:
@@ -52,7 +56,7 @@ class HybridGrokkyEngine:
                     self.threads[user_id] = res.json().get("id")
             except Exception as exc:  # pragma: no cover - network
                 self.threads[user_id] = None
-                print(f"OpenAI thread creation failed: {exc}")
+                logger.error("OpenAI thread creation failed: %s", exc, exc_info=True)
         return self.threads.get(user_id)
 
     async def add_memory(self, user_id: str, content: str, role="user"):
@@ -69,7 +73,7 @@ class HybridGrokkyEngine:
                     timeout=15,
                 )
             except Exception as exc:  # pragma: no cover - network
-                print(f"OpenAI add_memory failed: {exc}")
+                logger.warning("OpenAI add_memory failed: %s", exc, exc_info=True)
 
     async def search_memory(self, user_id: str, query: str, limit: int = 5) -> str:
         """Выполняет поиск в памяти через GPT-4o mini Assistant.
@@ -127,7 +131,7 @@ class HybridGrokkyEngine:
                 if data:
                     return data[0]["content"][0]["text"]["value"]
             except Exception as exc:  # pragma: no cover - network
-                print(f"OpenAI search_memory failed: {exc}")
+                logger.error("OpenAI search_memory failed: %s", exc, exc_info=True)
         return ""
 
     async def get_recent_memory(self, user_id: str, limit: int = 10) -> str:
@@ -159,7 +163,7 @@ class HybridGrokkyEngine:
                 if context_parts:
                     return "\n".join(context_parts)
             except Exception as exc:  # pragma: no cover - network
-                print(f"OpenAI get_recent_memory failed: {exc}")
+                logger.warning("OpenAI get_recent_memory failed: %s", exc, exc_info=True)
         return ""
 
     async def generate_with_xai(

--- a/utils/knowtheworld.py
+++ b/utils/knowtheworld.py
@@ -55,7 +55,7 @@ async def fetch_news(topic: str) -> str:
             message = data.get("choices", [{}])[0].get("message", {})
             return message.get("content", "").strip()
         except Exception as e:
-            logger.error("Не удалось получить новости: %s", e)
+            logger.warning("Не удалось получить новости: %s", e, exc_info=True)
             return ""
 
 async def know_the_world_task(
@@ -93,8 +93,8 @@ async def know_the_world_task(
             entry = f"#knowtheworld {datetime.now().isoformat()}: {summary}"
             await engine.add_memory("journal", entry, role="journal")
             logger.info("know_the_world entry recorded")
-        except Exception as e:
-            logger.error("Ошибка know_the_world_task: %s", e)
+        except Exception:
+            logger.exception("Ошибка know_the_world_task")
         count += 1
         if iterations is not None and count >= iterations:
             break


### PR DESCRIPTION
## Summary
- replace prints with structured logging in `HybridGrokkyEngine`
- log exceptions in news retrieval and know_the_world background task

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d30a2e208329982795ab046a5d9e