### PR TITLE
feat: load quantized grok weights

### DIFF
--- a/SLNCX/wulf_inference.py
+++ b/SLNCX/wulf_inference.py
@@ -1,19 +1,94 @@
-from typing import Optional
-import importlib
+"""Lightweight Grok-1 inference utilities.
+
+This module loads a quantised checkpoint produced by the training utilities
+and performs token-by-token generation.  It purposely keeps the implementation
+minimal so that the tiny test checkpoint can be executed quickly on CPU.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import torch
+
+from .nanogpt_model import GPT, GPTConfig
+from utils.dynamic_weights import DynamicWeights
+
+
+def _dequantize(tensor_or_dict: object) -> torch.Tensor:
+    """Return a de-quantised tensor.
+
+    The quantisation format mirrors the output of :mod:`SLNCX.quantize` where
+    each tensor is stored as an ``int8`` weight matrix and a corresponding
+    floating point scale.  If ``tensor_or_dict`` is already a tensor it is
+    returned as-is.
+    """
+
+    if isinstance(tensor_or_dict, dict) and "weight" in tensor_or_dict and "scale" in tensor_or_dict:
+        weight = tensor_or_dict["weight"].to(torch.float32)
+        scale = tensor_or_dict["scale"].to(torch.float32)
+        return weight * scale
+    return torch.as_tensor(tensor_or_dict)
+
+
+def _load_model(ckpt_path: str) -> GPT:
+    """Load a quantised Grok-1 checkpoint."""
+
+    ckpt: Dict[str, object] = torch.load(Path(ckpt_path), map_location="cpu")
+    config = GPTConfig(**ckpt["config"])
+    model = GPT(config)
+    state_dict = {k: _dequantize(v) for k, v in ckpt["model"].items()}
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def _encode(text: str) -> list[int]:
+    """Very small character-level encoding used for the tests."""
+
+    return [ord(c) for c in text]
+
+
+def _decode(tokens: list[int]) -> str:
+    return "".join(chr(t) for t in tokens)
 
 
 def generate(
     prompt: str,
     ckpt_path: str = "out/ckpt.pt",
     api_key: Optional[str] = None,
+    *,
+    seed: Optional[int] = None,
+    max_new_tokens: int = 20,
 ) -> str:
-    """Proxy to :func:`model.generate` for backward compatibility."""
+    """Generate text from ``prompt`` using a quantised model.
 
-    try:
-        model_module = importlib.import_module(".model", __package__)
-        return model_module.generate(prompt, ckpt_path, api_key)
-    except ModuleNotFoundError:
-        from utils.dynamic_weights import DynamicWeights
+    ``DynamicWeights`` are consulted to derive a ``pulse`` value that modulates
+    the sampling temperature.  ``seed`` controls the RNG used for sampling to
+    allow deterministic outputs in tests.
+    """
 
-        controller = DynamicWeights()
-        return controller.generate_response(prompt, api_key)
+    model = _load_model(ckpt_path)
+    dw = DynamicWeights()
+    pulse = dw.pulse_from_prompt(prompt, api_key)
+    temperature = 0.8 + 0.2 * pulse
+
+    device = next(model.parameters()).device
+    idx = torch.tensor([_encode(prompt)], dtype=torch.long, device=device)
+    generator = torch.Generator(device=device)
+    if seed is not None:
+        generator.manual_seed(seed)
+
+    out_tokens: list[int] = []
+    for _ in range(max_new_tokens):
+        with torch.no_grad():
+            logits, _ = model(idx[:, -model.config.block_size :])
+        logits = logits[:, -1, :] / temperature
+        probs = torch.softmax(logits, dim=-1)
+        next_id = torch.multinomial(probs, num_samples=1, generator=generator)
+        idx = torch.cat((idx, next_id), dim=1)
+        out_tokens.append(int(next_id))
+
+    return _decode(out_tokens)
+

--- a/tests/test_wulf_inference.py
+++ b/tests/test_wulf_inference.py
@@ -1,0 +1,54 @@
+"""Tests for the Grok-1 inference wrapper."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import torch
+
+from SLNCX.nanogpt_model import GPT, GPTConfig
+from SLNCX import wulf_inference
+
+
+def _create_quantised_checkpoint(path: Path) -> None:
+    """Create a tiny quantised checkpoint for testing."""
+
+    torch.manual_seed(0)
+    config = GPTConfig(
+        block_size=16,
+        vocab_size=256,
+        n_layer=1,
+        n_head=1,
+        n_embd=32,
+        dropout=0.0,
+        bias=True,
+    )
+    model = GPT(config)
+    q_state = {}
+    for key, tensor in model.state_dict().items():
+        max_val = float(tensor.abs().max())
+        scale = max(max_val / 127.0, 1e-8)
+        q_state[key] = {
+            "weight": torch.round(tensor / scale).to(torch.int8),
+            "scale": torch.tensor(scale, dtype=torch.float32),
+        }
+    ckpt = {"config": dataclasses.asdict(config), "model": q_state}
+    torch.save(ckpt, path)
+
+
+def test_generate_is_deterministic(tmp_path, monkeypatch):
+    ckpt = tmp_path / "grok.pt"
+    _create_quantised_checkpoint(ckpt)
+
+    # Avoid network calls from DynamicWeights.
+    monkeypatch.setattr(
+        wulf_inference.DynamicWeights,
+        "pulse_from_prompt",
+        lambda self, prompt, api_key=None: 0.0,
+    )
+
+    out1 = wulf_inference.generate("hi", ckpt_path=str(ckpt), seed=0, max_new_tokens=5)
+    out2 = wulf_inference.generate("hi", ckpt_path=str(ckpt), seed=0, max_new_tokens=5)
+    assert out1 == out2
+


### PR DESCRIPTION
## Summary
- load Grok-1 quantized weights and generate tokens in `wulf_inference`
- add tests to ensure deterministic generation given a fixed seed

## Testing
- `ruff SLNCX/wulf_inference.py tests/test_wulf_inference.py`
- `pytest tests/test_wulf_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e5c91b5083299f49393710e01e58