### PR TITLE
Add multimodal support to SLNCX generation

### DIFF
--- a/tests/test_multimodal_generate.py
+++ b/tests/test_multimodal_generate.py
@@ -1,0 +1,23 @@
+class DummyDW:
+    def generate_response(self, prompt, api_key=None):
+        return prompt
+
+
+def test_generate_image_audio_different(monkeypatch):
+    import importlib
+    import jax
+
+    monkeypatch.setattr(jax.config, "update", lambda *a, **k: None)
+    model = importlib.import_module("SLNCX.model")
+
+    monkeypatch.setattr(model, "analyze_image", lambda path: "img feature")
+    monkeypatch.setattr(model, "analyze_audio", lambda path: "audio feature")
+    monkeypatch.setattr(model, "DynamicWeights", lambda: DummyDW())
+
+    text = "hello"
+    out_img = model.generate(text, image="pic.png")
+    out_audio = model.generate(text, audio="sound.wav")
+
+    assert out_img != out_audio
+    assert "img feature" in out_img
+    assert "audio feature" in out_audio

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -1,0 +1,24 @@
+"""Simple wrapper around OpenAI audio transcription API."""
+from __future__ import annotations
+
+import os
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def analyze_audio(audio_path: str) -> str:
+    """Return a short transcription for the provided audio file."""
+    try:
+        with open(audio_path, "rb") as audio_file:
+            response = client.audio.transcriptions.create(
+                model="whisper-1",
+                file=audio_file,
+            )
+        text = getattr(response, "text", "")
+        return text.strip() if isinstance(text, str) else ""
+    except Exception as exc:  # pragma: no cover - network or file errors
+        return f"Audio error: {exc}"
+
+
+__all__ = ["analyze_audio"]


### PR DESCRIPTION
## Summary
- allow `SLNCX.model.generate` to take optional image and audio paths
- add audio transcription helper and pipe features through wulf integration
- test that image and audio prompts yield different responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e62a19608329a470b5c2b3abeb08