### PR TITLE
Refactor dynamic knowledge queries

### DIFF
--- a/tests/test_dynamic_weights.py
+++ b/tests/test_dynamic_weights.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from utils.dynamic_weights import DynamicWeights
+import asyncio
+import time
+import pytest
+
+from utils.dynamic_weights import DynamicWeights, aget_dynamic_knowledge
 
 
 def test_weights_shift_with_pulse(monkeypatch):
@@ -19,3 +23,26 @@ def test_weights_shift_with_pulse(monkeypatch):
     )
     weights = dw.weights_for_prompt("hi")
     assert weights[2] == max(weights)
+
+
+@pytest.mark.asyncio
+async def test_get_dynamic_knowledge_parallel(monkeypatch):
+    async def fake_grok(prompt, api_key=None):
+        await asyncio.sleep(0.1)
+        return "Grok-3 offline"
+
+    async def fake_gpt(prompt, api_key=None):
+        await asyncio.sleep(0.1)
+        return "ok"
+
+    import utils.dynamic_weights as dw
+
+    monkeypatch.setattr(dw, "query_grok3", fake_grok)
+    monkeypatch.setattr(dw, "query_gpt4", fake_gpt)
+
+    start = time.perf_counter()
+    result = await aget_dynamic_knowledge("hi")
+    duration = time.perf_counter() - start
+
+    assert result == "ok"
+    assert duration < 0.15


### PR DESCRIPTION
## Summary
- switch Grok-3 and GPT-4 lookups to `httpx.AsyncClient`
- run knowledge lookups in parallel and expose an async helper
- add async test for parallel knowledge retrieval

## Testing
- `pytest tests/test_dynamic_weights.py tests/test_utils42.py tests/test_context_neural_processor.py tests/test_wulf_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6893e68519cc83298824d2982a8e1e04