### PR TITLE
Use GPT-4o for dynamic weights and expose SLNCX mode

### DIFF
--- a/SLNCX/wulf_integration.py
+++ b/SLNCX/wulf_integration.py
@@ -67,9 +67,11 @@ def generate_response(
 ) -> str:
     """Generate a response using either SLNCX or external models.
 
-    If an ``engine`` and ``user_id`` are provided, the function will search the
-    user's memory for additional context and store the prompt/response pair
-    after generation.
+    ``mode`` accepts ``"slncx"`` (or ``"wulf"`` for backwards compatibility)
+    to query the local SLNCX core. Any other value falls back to the external
+    dynamic-knowledge path. If an ``engine`` and ``user_id`` are provided, the
+    function will search the user's memory for additional context and store the
+    prompt/response pair after generation.
     """
 
     log_entry = {"prompt": prompt, "timestamp": time.time()}
@@ -85,7 +87,7 @@ def generate_response(
     prompt_with_context = prompt if not context else f"{context}\n\n{prompt}"
 
     try:
-        if mode == "wulf":
+        if mode in {"wulf", "slncx"}:
             snippet_limit = int(os.getenv("WULF_SNIPPET_LIMIT", "3"))
             snippets = ""
             if snippet_limit > 0:

--- a/server.py
+++ b/server.py
@@ -565,7 +565,7 @@ async def handle_text(message: Message, text: str) -> None:
         reply = await asyncio.to_thread(
             generate_response,
             text,
-            "wulf",
+            "slncx",
             user_id=str(message.chat.id),
             engine=engine,
         )

--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -36,12 +36,12 @@ async def query_grok3(prompt: str, api_key: Optional[str] = None) -> str:
 
 
 async def query_gpt4(
-    prompt: str, api_key: Optional[str] = None, model: str = "gpt-3.5"
+    prompt: str, api_key: Optional[str] = None, model: str = "gpt-4o"
 ) -> str:
-    """Call the GPT-3.5 API as a secondary knowledge base.
+    """Call the GPT-4o API as a secondary knowledge base.
 
-    The default model is set to ``gpt-3.5`` to align with SLNCX's requirement
-    for dynamic weighting based on the GPT-3.5 series."""
+    The default model is set to ``gpt-4o`` so SLNCX can leverage the latest
+    OpenAI engine when deriving dynamic weights."""
     api_key = api_key or os.getenv("OPENAI_API_KEY")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     payload = {
@@ -66,16 +66,16 @@ async def query_gpt4(
                 "a",
                 encoding="utf-8",
             ) as f:
-                f.write(f"{time.time()}: GPT-3.5 API failed - {exc}\n")
+                f.write(f"{time.time()}: GPT-4o API failed - {exc}\n")
         except OSError:
             pass
-        return "GPT-3.5 offline"
+        return "GPT-4o offline"
 
 
 async def aget_dynamic_knowledge(
     prompt: str, api_key: Optional[str] = None
 ) -> str:
-    """Fetch knowledge from Grok-3 with GPT-3.5 fallback asynchronously."""
+    """Fetch knowledge from Grok-3 with GPT-4o fallback asynchronously."""
     grok_task = query_grok3(prompt, api_key)
     gpt_task = query_gpt4(prompt, api_key)
     grok_res, gpt_res = await asyncio.gather(grok_task, gpt_task)


### PR DESCRIPTION
## Summary
- switch dynamic weights fallback model from gpt-3.5 to gpt-4o
- allow `slncx` alias for local SLNCX core and wire server to use it

## Testing
- `pytest` *(fails: AttributeError: 'function' object has no attribute 'register')*

------
https://chatgpt.com/codex/tasks/task_e_6893f9525bc88329baf7ab95d0577906