### PR TITLE
Integrate SLNCX model with interactive weight server

### DIFF
--- a/SLNCX/model.py
+++ b/SLNCX/model.py
@@ -48,6 +48,7 @@ from pydantic import BaseModel
 from .scripts.fail_log import log_failure
 from .scripts.session_logger import log_session
 from utils.dynamic_weights import DynamicWeights
+from utils.server2 import generate_text
 from .train import prepare_data, restore, save_checkpoint, train as train_model  # noqa: F401
 
 WULF_PROMPT = (
@@ -69,14 +70,12 @@ WULF_PROMPT = (
 def generate(prompt: str, ckpt_path: str = "out/ckpt.pt", api_key: Optional[str] = None) -> str:
     """Return a response from the lightweight SLNCX model.
 
-    This function routes dynamic weights directly through the model layer so that
-    external callers can obtain answers without depending on intermediary helper
-    modules.
+    The prompt is forwarded to the interactive weights server to obtain a
+    response without relying on intermediary helper modules.
     """
 
-    controller = DynamicWeights()
     full_prompt = f"{WULF_PROMPT}\nUser: {prompt}"
-    return controller.generate_response(full_prompt, api_key)
+    return generate_text(full_prompt)
 
 # ``jax_spmd_mode`` was removed in newer releases of JAX. Guard the update so
 # older versions that still support the flag continue to work without raising an

--- a/server.py
+++ b/server.py
@@ -66,7 +66,7 @@ from utils.repo_monitor import monitor_repository
 from utils.vision import analyze_image
 from utils.plugins.coder import interpret_code
 from importlib import import_module
-from SLNCX.wulf_integration import generate_response
+from SLNCX.model import generate as slncx_generate
 
 # Импортируем наш новый движок
 from utils.vector_engine import VectorGrokkyEngine
@@ -387,13 +387,7 @@ async def cmd_slncx(message: Message):
         await message.reply("SLNCX mode on. /slncxoff to exit.")
     else:
         prompt = parts[1]
-        reply = await asyncio.to_thread(
-            generate_response,
-            prompt,
-            "wulf",
-            user_id=str(chat_id),
-            engine=engine,
-        )
+        reply = await asyncio.to_thread(slncx_generate, prompt)
         await reply_split(message, reply)
 
 
@@ -562,13 +556,7 @@ async def handle_text(message: Message, text: str) -> None:
         return
 
     if SLNCX_MODE.get(message.chat.id):
-        reply = await asyncio.to_thread(
-            generate_response,
-            text,
-            "slncx",
-            user_id=str(message.chat.id),
-            engine=engine,
-        )
+        reply = await asyncio.to_thread(slncx_generate, text)
         await reply_split(message, reply)
         return
 

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,5 +1,5 @@
 import importlib
-
+import sys
 import pytest
 from fastapi.testclient import TestClient
 
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("API_KEY", "SECRET")
+    for mod in ["aiogram", "aiogram.types", "aiogram.enums", "aiogram.filters", "aiogram.exceptions"]:
+        sys.modules.pop(mod, None)
     import server
     importlib.reload(server)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -20,6 +20,8 @@ def test_plugin_discovery() -> None:
 
 @pytest.mark.asyncio
 async def test_command_routing(monkeypatch) -> None:
+    for mod in ["aiogram", "aiogram.types", "aiogram.enums", "aiogram.filters", "aiogram.exceptions"]:
+        sys.modules.pop(mod, None)
     import server
     importlib.reload(server)
     outputs = []

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -109,11 +109,16 @@ eng_stub = type("Engine", (), {})
 _add_stub("utils.vector_engine", VectorGrokkyEngine=eng_stub)
 _add_stub("utils.hybrid_engine", HybridGrokkyEngine=eng_stub)
 _add_stub("utils.context_neural_processor", parse_and_store_file=_stub_async())
-_add_stub("SLNCX.wulf_integration", generate_response=_stub_async())
+_add_stub("SLNCX.model", generate=_stub_async())
 
 import server  # noqa: E402
 sys.modules.pop("utils.plugins", None)
 sys.modules.pop("utils", None)
+sys.modules.pop("aiogram", None)
+sys.modules.pop("aiogram.types", None)
+sys.modules.pop("aiogram.enums", None)
+sys.modules.pop("aiogram.filters", None)
+sys.modules.pop("aiogram.exceptions", None)
 import importlib  # noqa: E402
 importlib.invalidate_caches()
 


### PR DESCRIPTION
## Summary
- Route `/slncx` commands directly to the SLNCX model
- Use interactive weight server for SLNCX responses
- Add lightweight Flask fallback and expose `generate_text` helper
- Update tests to match new SLNCX entry point

## Testing
- `ruff server.py SLNCX/model.py utils/server2.py tests/test_webhook.py tests/test_url_validation.py tests/test_plugins.py tests/test_api_key.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68970236d7808329bf32f04be5abe506