### PR TITLE
feat: add chat and memory managers

### DIFF
--- a/utils/grok_chat_manager.py
+++ b/utils/grok_chat_manager.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+from typing import Dict, List
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class GrokChatManager:
+    """Manage chat history and communication with xAI API."""
+
+    def __init__(self, api_key: str | None) -> None:
+        self.api_key = api_key
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        self.history: Dict[str, List[dict]] = {}
+
+    def add_message(self, session_id: str, role: str, content: str) -> None:
+        messages = self.history.setdefault(session_id, [])
+        messages.append({"role": role, "content": content})
+        # keep last 20 messages
+        if len(messages) > 20:
+            self.history[session_id] = messages[-20:]
+
+    def get_messages(self, session_id: str) -> List[dict]:
+        return self.history.get(session_id, [])
+
+    async def _request(self, payload: dict) -> str:
+        backoff = 1.0
+        for attempt in range(3):
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    res = await client.post(
+                        "https://api.x.ai/v1/chat/completions",
+                        headers=self.headers,
+                        json=payload,
+                    )
+                if res.status_code == 200:
+                    data = res.json()
+                    return data["choices"][0]["message"]["content"]
+                if res.status_code in (400, 422):
+                    raise RuntimeError(f"Bad request: {res.text}")
+                if res.status_code == 401:
+                    raise RuntimeError("Unauthorized: check API key")
+                if res.status_code == 429:
+                    await asyncio.sleep(backoff)
+                    backoff *= 2
+                    continue
+                raise RuntimeError(f"xAI error {res.status_code}: {res.text}")
+            except httpx.RequestError as e:
+                logger.warning("Request error: %s", e)
+                if attempt == 2:
+                    raise RuntimeError(f"Request failed: {e}")
+                await asyncio.sleep(backoff)
+                backoff *= 2
+        raise RuntimeError("Max retries exceeded")
+
+    async def safe_chat_completion(self, session_id: str, context: str = "") -> str:
+        messages = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.extend(self.get_messages(session_id))
+        payload = {"model": "grok-3", "messages": messages}
+        return await self._request(payload)
+
+    async def quick_chat(self, messages: List[dict]) -> str:
+        payload = {"model": "grok-3", "messages": messages}
+        return await self._request(payload)

--- a/utils/memory_manager.py
+++ b/utils/memory_manager.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+import time
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class ImprovedMemoryManager:
+    """Store conversation history with optional Pinecone backend."""
+
+    def __init__(self, api_key: str | None, index: str | None) -> None:
+        self.api_key = api_key
+        self.index_name = index
+        self.local_memory: Dict[str, List[str]] = {}
+        self.index = None
+        if api_key and index:
+            try:
+                from pinecone import Pinecone
+
+                pc = Pinecone(api_key=api_key)
+                self.index = pc.Index(index)
+            except Exception as e:  # pragma: no cover - optional
+                logger.warning("Pinecone init failed: %s", e)
+                self.index = None
+
+    async def save(self, user_id: str, content: str, role: str = "user") -> None:
+        if self.index:
+            try:  # pragma: no cover - network
+                await asyncio.to_thread(
+                    self.index.upsert,
+                    vectors=[(
+                        f"{user_id}-{int(time.time()*1000)}",
+                        [0.0] * 8,
+                        {"text": content, "role": role, "user_id": user_id},
+                    )],
+                )
+            except Exception as e:
+                logger.warning("Pinecone save failed: %s", e)
+        messages = self.local_memory.setdefault(user_id, [])
+        messages.append(f"{role}: {content}")
+        if len(messages) > 50:
+            self.local_memory[user_id] = messages[-50:]
+
+    async def retrieve(self, user_id: str, _query: str) -> str:
+        if self.index:
+            try:  # pragma: no cover - network
+                res = await asyncio.to_thread(
+                    self.index.query,
+                    vector=[0.0] * 8,
+                    filter={"user_id": user_id},
+                    top_k=5,
+                    include_metadata=True,
+                )
+                texts = [
+                    m.get("metadata", {}).get("text", "") for m in res.get("matches", [])
+                ]
+                if texts:
+                    return "\n".join(texts)
+            except Exception as e:
+                logger.warning("Pinecone query failed: %s", e)
+        return "\n".join(self.local_memory.get(user_id, [])[-10:])


### PR DESCRIPTION
## Summary
- add GrokChatManager with retry and status-code handling for xAI API
- add ImprovedMemoryManager with optional Pinecone fallback
- use new managers in server handler and expose /health/grok endpoint

## Testing
- `ruff server.py utils/grok_chat_manager.py utils/memory_manager.py --select=E9,F63,F7,F82`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689795774c388329b3054435fae603de