### PR TITLE
chore: remove SLNCX references from dynamic weights

### DIFF
--- a/utils/dynamic_weights.py
+++ b/utils/dynamic_weights.py
@@ -40,8 +40,8 @@ async def query_gpt4(
 ) -> str:
     """Call the GPT-4o API as a secondary knowledge base.
 
-    The default model is set to ``gpt-4o`` so SLNCX can leverage the latest
-    OpenAI engine when deriving dynamic weights."""
+    The default model is ``gpt-4o`` to leverage the latest OpenAI engine when
+    deriving dynamic weights."""
     api_key = api_key or os.getenv("OPENAI_API_KEY")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     payload = {
@@ -126,7 +126,7 @@ class DynamicWeights:
         # Simple heuristic: longer knowledge implies a stronger pulse.
         # The denominator is tuned to 300 so that relatively small snippets of
         # knowledge can already yield noticeable pulse values, enabling the
-        # lightweight SLNCX model to vary its responses.
+        # lightweight model to vary its responses.
         pulse = min(len(knowledge) / 300.0, 1.0)
         return max(pulse, 0.0)
 
@@ -174,7 +174,7 @@ class DynamicWeights:
         The method derives a ``pulse`` from ``prompt`` and appends a style hint
         before querying :func:`get_dynamic_knowledge` again. Low pulse values
         yield terse answers while higher pulses encourage more elaborate
-        replies. This enables SLNCX to "speak" without relying on static
+        replies. This enables the system to respond without relying on static
         templates.
         """
 


### PR DESCRIPTION
## Summary
- remove SLNCX mentions from dynamic weight utilities

## Testing
- `ruff check utils/dynamic_weights.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689841de35dc8329871ab0f5d7442a07