### PR TITLE
feat: secure public API routes

### DIFF
--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -31,3 +31,9 @@ def test_api_key_valid(app):
         "/42", headers={"X-API-Key": "SECRET"}, json={"cmd": "42"}
     )
     assert response.status_code == 200
+
+
+def test_feedback_requires_api_key(app):
+    client = TestClient(app)
+    response = client.post("/feedback", json={})
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add APIRouter with default verify_api_key dependency
- protect feedback and other GET/POST endpoints via API key
- test missing API key on feedback returns 401

## Testing
- `python -m pyflakes server.py tests/test_api_key.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898af51d4088329a7a783c137526a3c