### PR TITLE
Add command and data transfer metrics

### DIFF
--- a/server.py
+++ b/server.py
@@ -57,7 +57,13 @@ from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-from utils.metrics import REQUEST_LATENCY, record_tokens
+from utils.metrics import (
+    REQUEST_LATENCY,
+    record_tokens,
+    record_error,
+    record_command_usage,
+    record_data_transfer,
+)
 
 from utils.dayandnight import day_and_night_task
 from utils.mirror import mirror_task
@@ -172,6 +178,7 @@ dynamic_weights = DynamicWeights([0.5, 0.5])
 rl_trainer = RLTrainer(dynamic_weights)
 chat_manager: GrokChatManager | None = None
 memory_manager: ImprovedMemoryManager | None = None
+
 
 async def rl_trainer_task() -> None:
     while True:
@@ -326,7 +333,7 @@ async def reply_split(message: Message, text: str) -> None:
     limit = 4096
     # Reserve space for the prefix added to each chunk.
     chunk_size = limit - 100
-    chunks = [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+    chunks = [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
     total = len(chunks)
 
     for idx, chunk in enumerate(chunks, start=1):
@@ -420,9 +427,6 @@ async def cmd_clearmemory(message: Message):
         logger.error(f"Ошибка при очистке памяти: {e}")
         logger.error(traceback.format_exc())
         await reply_split(message, "🌀 Произошла ошибка при очистке памяти")
-
-
-
 
 
 @dp.message(Command("file"))
@@ -526,6 +530,7 @@ async def coder_choice(callback: types.CallbackQuery):
             callback.message.chat.id, file, caption="Here is the code output."
         )
 
+
 async def telegram_message_handler_fixed(message: Message, text: str) -> None:
     """Improved handler using chat and memory managers."""
     if not text:
@@ -587,6 +592,8 @@ async def telegram_message_handler_fixed(message: Message, text: str) -> None:
 
 async def handle_text(message: Message, text: str) -> None:
     await telegram_message_handler_fixed(message, text)
+
+
 async def handle_photo(message: Message) -> None:
     """Analyze photo with OpenAI vision."""
     if not engine:
@@ -718,8 +725,12 @@ app.add_middleware(SlowAPIMiddleware)
 @app.middleware("http")
 async def _metrics_middleware(request: Request, call_next):
     start = time.perf_counter()
+    req_size = int(request.headers.get("content-length") or 0)
+    record_data_transfer("in", req_size)
     response = await call_next(request)
     duration = time.perf_counter() - start
+    resp_size = int(response.headers.get("content-length") or 0)
+    record_data_transfer("out", resp_size)
     REQUEST_LATENCY.labels(endpoint=request.url.path).observe(duration)
     return response
 
@@ -738,6 +749,7 @@ async def handle_webhook(request: Request):
                 len(request_body),
                 MAX_WEBHOOK_BODY_SIZE,
             )
+            record_error("payload_too_large")
             return PlainTextResponse(status_code=413, content="payload too large")
         logger.info(f"Получены данные вебхука длиной {len(request_body)} байт")
         data = json.loads(request_body)
@@ -747,6 +759,7 @@ async def handle_webhook(request: Request):
     except (json.JSONDecodeError, TelegramAPIError) as e:
         logger.error(f"Ошибка обработки вебхука: {e}")
         logger.error(traceback.format_exc())
+        record_error("webhook")
         return PlainTextResponse(status_code=500, content="error")
 
 
@@ -787,7 +800,9 @@ async def handle_42_api(request: Request, _=Depends(verify_api_key)):
         data = {}
     cmd = data.get("cmd") or request.query_params.get("cmd", "")
     if cmd not in {"when", "mars", "42"}:
+        record_error("unsupported_command")
         return JSONResponse({"error": "Unsupported command"}, status_code=400)
+    record_command_usage(cmd)
     result = await handle(cmd)
     record_tokens("42", len(str(result)))
     return JSONResponse({"response": result["response"]})

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,9 +2,13 @@ from utils.metrics import (
     TOKENS,
     ERRORS,
     MEMORY_HITS,
+    COMMANDS,
+    DATA_TRANSFERRED,
     record_tokens,
     record_error,
     record_memory_hit,
+    record_command_usage,
+    record_data_transfer,
 )
 
 
@@ -26,3 +30,17 @@ def test_memory_hit_counter_increments():
     before = MEMORY_HITS._value.get()
     record_memory_hit()
     assert MEMORY_HITS._value.get() == before + 1
+
+
+def test_command_usage_counter_increments():
+    counter = COMMANDS.labels(command="test")
+    before = counter._value.get()
+    record_command_usage("test")
+    assert counter._value.get() == before + 1
+
+
+def test_data_transfer_counter_increments():
+    counter_in = DATA_TRANSFERRED.labels(direction="in")
+    before_in = counter_in._value.get()
+    record_data_transfer("in", 10)
+    assert counter_in._value.get() == before_in + 10

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def test_metrics_exposed_for_command(monkeypatch):
+    for mod in [
+        "aiogram",
+        "aiogram.types",
+        "aiogram.enums",
+        "aiogram.filters",
+        "aiogram.exceptions",
+    ]:
+        sys.modules.pop(mod, None)
+    import server
+    importlib.reload(server)
+
+    async def dummy_handle(cmd):
+        return {"response": "ok", "pulse": 0}
+
+    async def dummy_startup():
+        pass
+
+    async def dummy_shutdown():
+        pass
+
+    monkeypatch.setattr(server, "handle", dummy_handle)
+    monkeypatch.setattr(server, "on_startup", dummy_startup)
+    monkeypatch.setattr(server, "on_shutdown", dummy_shutdown)
+
+    client = TestClient(server.app)
+    resp = client.post("/42", json={"cmd": "42"})
+    assert resp.status_code == 200
+
+    metrics = client.get("/metrics").text
+    assert 'commands_total{command="42"}' in metrics
+    assert 'data_transferred_bytes_total{direction="in"}' in metrics

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -16,6 +16,16 @@ ERRORS = Counter("errors_total", "Total errors", ["type"])
 # Counter for memory cache hits.
 MEMORY_HITS = Counter("memory_hits_total", "Memory hits")
 
+# Counter for command usage.
+COMMANDS = Counter(
+    "commands_total", "Number of executed commands", ["command"]
+)
+
+# Counter for transferred data volume in bytes.
+DATA_TRANSFERRED = Counter(
+    "data_transferred_bytes_total", "Bytes transferred", ["direction"]
+)
+
 
 def record_tokens(model: str, count: int) -> None:
     """Record ``count`` tokens used by ``model``."""
@@ -30,3 +40,13 @@ def record_error(err_type: str) -> None:
 def record_memory_hit() -> None:
     """Increment memory hit counter."""
     MEMORY_HITS.inc()
+
+
+def record_command_usage(command: str) -> None:
+    """Increment command usage counter for ``command``."""
+    COMMANDS.labels(command=command).inc()
+
+
+def record_data_transfer(direction: str, amount: int) -> None:
+    """Record ``amount`` bytes transferred in ``direction`` (in/out)."""
+    DATA_TRANSFERRED.labels(direction=direction).inc(amount)


### PR DESCRIPTION
## Summary
- track command usage and data throughput with new Prometheus counters
- record webhook and command errors in metrics
- expose command usage metrics after invoking an API command

## Testing
- `pytest`
- `flake8 --max-line-length=120 utils/metrics.py server.py tests/test_metrics.py tests/test_metrics_endpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_6898b1409a5083298794c1890fe73205