### PR TITLE
feat: add commands listing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ pilot seat while modes snap on and off.
 2. Run the server: `python server.py`
 3. Talk to your bot and try `/search cats` to hit the example plugin.
 
+### Commands page
+
+Visit [http://localhost:8000/commands](http://localhost:8000/commands) to see a list of all loaded plugin commands.
+
 ### Why Grokky is different
 
 The AI entity mixes several engines. Grok 1 handles local inference while remote

--- a/requirements.lock
+++ b/requirements.lock
@@ -453,6 +453,10 @@ jmp==0.0.4 \
     --hash=sha256:5dfeb0fd7c7a9f72a70fff0aab9d0cbfae32a809c02f4037ff3485ceb33e1730 \
     --hash=sha256:6aa7adbddf2bd574b28c7faf6e81a735eb11f53386447896909c6968dc36807d
     # via dm-haiku
+jinja2==3.1.4 \
+    --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
+    --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
+    # via -r requirements.txt
 limits==5.4.0 \
     --hash=sha256:1afb03c0624cf004085532aa9524953f2565cf8b0a914e48dda89d172c13ceb7 \
     --hash=sha256:27ebf55118e3c9045f0dbc476f4559b26d42f4b043db670afb8963f36cf07fd9
@@ -564,6 +568,10 @@ magic-filter==1.0.12 \
     --hash=sha256:4751d0b579a5045d1dc250625c4c508c18c3def5ea6afaf3957cb4530d03f7f9 \
     --hash=sha256:e5929e544f310c2b1f154318db8c5cdf544dd658efa998172acd2e4ba0f6c6a6
     # via aiogram
+markupsafe==3.0.2 \
+    --hash=sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0 \
+    --hash=sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8
+    # via jinja2
 ml-dtypes==0.5.3 \
     --hash=sha256:01de48de4537dc3c46e684b969a40ec36594e7eeb7c69e9a093e7239f030a28a \
     --hash=sha256:0a1d68a7cb53e3f640b2b6a34d12c0542da3dd935e560fdf463c0c77f339fc20 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ jaxlib==0.7.0
 dm-haiku==0.0.14
 sentencepiece==0.2.0
 reportlab==4.4.3
+jinja2==3.1.4

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Grokky Commands</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2rem; }
+h1 { margin-bottom: 1rem; }
+.plugin { margin-bottom: 1.5rem; }
+code { background: #f0f0f0; padding: 0.25rem 0.5rem; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>Available Commands</h1>
+{% for plugin in plugins %}
+<div class="plugin">
+  <h2>{{ plugin.name }}{% if plugin.description %} - {{ plugin.description }}{% endif %}</h2>
+  <ul>
+  {% for cmd in plugin.commands %}
+    <li><code>/{{ cmd }}</code></li>
+  {% endfor %}
+  </ul>
+</div>
+{% endfor %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- list plugin commands via /commands page
- simplify commands interface and drop screenshot to avoid binary files
- document commands page in README

## Testing
- `pytest`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6898af6565dc832997aceca17cc46803