### PR TITLE
feat: add consolidated /help command

### DIFF
--- a/server.py
+++ b/server.py
@@ -348,6 +348,34 @@ async def reply_split(message: Message, text: str) -> None:
             await bot.send_message(message.chat.id, full_text)
 
 
+STANDARD_COMMANDS = {
+    "help": "show available commands",
+    "voiceon": "speak",
+    "voiceoff": "mute",
+    "voice": "voice commands",
+    "coder": "coder mode",
+    "coderoff": "coder mode off",
+    "status": "status",
+    "clearmemory": "clear memory",
+    "file": "process file",
+}
+
+
+@dp.message(Command("help"))
+async def cmd_help(message: Message):
+    lines = [f"/{cmd} - {desc}" for cmd, desc in STANDARD_COMMANDS.items()]
+    for plugin in PLUGINS:
+        for _cmd, func in plugin.commands.items():
+            desc = (
+                (func.__doc__ or "").strip()
+                or getattr(plugin, "description", "").strip()
+                or (type(plugin).__doc__ or "").strip()
+            )
+            line = f"/{_cmd} - {desc}" if desc else f"/{_cmd}"
+            lines.append(line)
+    await reply_split(message, "\n".join(lines))
+
+
 @dp.message(Command("voiceon"))
 async def cmd_voiceon(message: Message):
     VOICE_ENABLED[message.chat.id] = True
@@ -670,6 +698,7 @@ async def on_startup():
 
     try:
         command_list = [
+            types.BotCommand(command="help", description="help"),
             types.BotCommand(command="voiceon", description="speak"),
             types.BotCommand(command="voiceoff", description="mute"),
             types.BotCommand(command="coderoff", description="coder mode off"),

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_help_lists_plugins(monkeypatch):
+    for mod in [
+        "aiogram",
+        "aiogram.types",
+        "aiogram.enums",
+        "aiogram.filters",
+        "aiogram.exceptions",
+    ]:
+        sys.modules.pop(mod, None)
+    import server
+    importlib.reload(server)
+    outputs = []
+
+    async def fake_reply_split(message, text):
+        outputs.append(text)
+
+    monkeypatch.setattr(server, "reply_split", fake_reply_split)
+    msg = type("Msg", (), {"text": "/help"})()
+    for handler in server.dp.message.handlers:
+        for f in handler.filters:
+            commands = getattr(f.callback, "commands", [])
+            if "help" in commands:
+                await handler.callback(msg)
+                text = outputs[0]
+                for plugin in server.PLUGINS:
+                    for cmd in plugin.commands:
+                        assert f"/{cmd}" in text
+                return
+    pytest.fail("help handler not registered")


### PR DESCRIPTION
## Summary
- add /help handler that lists core and plugin commands via reply_split
- register help in Telegram command menu
- test that /help output includes all plugin commands

## Testing
- `flake8 server.py tests/test_help.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b4b6c0c4832980611bedf7dcced1