### PR TITLE
Validate document uploads by extension

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,8 @@ import tempfile
 from urllib.parse import urlparse
 from ipaddress import ip_address
 import time
+import mimetypes
+from pathlib import Path
 
 import httpx
 try:  # pragma: no cover - used only with aiogram installed
@@ -115,6 +117,7 @@ NEWS_MODEL = os.getenv("NEWS_MODEL", "gpt-4o")
 URL_RE = re.compile(r"https?://\S+")
 MAX_URL_LENGTH = int(os.getenv("MAX_URL_LENGTH", "2048"))
 MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE", "10485760"))
+ALLOWED_FILE_EXTENSIONS = {".txt", ".md", ".pdf"}
 BANNED_DOMAINS = {
     d.strip().lower()
     for d in os.getenv("BANNED_DOMAINS", "").split(",")
@@ -498,6 +501,15 @@ async def _process_document(message: Message, document):
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(resp.content)
             tmp_path = tmp.name
+        ext = Path(file.file_path).suffix.lower()
+        if not ext:
+            mime = mimetypes.guess_type(tmp_path)[0]
+            if mime:
+                ext = mimetypes.guess_extension(mime) or ""
+        if ext not in ALLOWED_FILE_EXTENSIONS:
+            allowed = ", ".join(sorted(ALLOWED_FILE_EXTENSIONS))
+            await message.reply(f"Unsupported file type. Allowed: {allowed}")
+            return
         result = await parse_and_store_file(tmp_path)
         await reply_split(message, result[:4000])
     except (httpx.HTTPError, OSError) as e:

--- a/tests/test_document_validation.py
+++ b/tests/test_document_validation.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+
+
+class DummyMessage:
+    def __init__(self):
+        self.replies: list[str] = []
+    async def reply(self, text):
+        self.replies.append(text)
+
+
+class DummyDocument:
+    def __init__(self, file_id):
+        self.file_id = file_id
+
+
+class DummyClient:
+    def __init__(self, content: bytes):
+        self._content = content
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url, timeout):
+        return types.SimpleNamespace(content=self._content)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_process_document_allows_txt(monkeypatch):
+    outputs = []
+
+    async def fake_parse(path):
+        return "PARSED"
+
+    async def fake_reply_split(message, text):
+        outputs.append(text)
+
+    async def fake_get_file(file_id):
+        return types.SimpleNamespace(file_path="doc/test.txt")
+
+    monkeypatch.setattr(server.bot, "get_file", fake_get_file)
+    monkeypatch.setattr(server.httpx, "AsyncClient", lambda *a, **k: DummyClient(b"hi"))
+    monkeypatch.setattr(server, "parse_and_store_file", fake_parse)
+    monkeypatch.setattr(server, "reply_split", fake_reply_split)
+
+    msg = DummyMessage()
+    doc = DummyDocument("1")
+    await server._process_document(msg, doc)
+
+    assert outputs == ["PARSED"]
+    assert msg.replies == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_process_document_rejects_exe(monkeypatch):
+    outputs = []
+    called = []
+
+    async def fake_parse(path):
+        called.append(path)
+        return "PARSED"
+
+    async def fake_reply_split(message, text):
+        outputs.append(text)
+
+    async def fake_get_file(file_id):
+        return types.SimpleNamespace(file_path="doc/test.exe")
+
+    monkeypatch.setattr(server.bot, "get_file", fake_get_file)
+    monkeypatch.setattr(server.httpx, "AsyncClient", lambda *a, **k: DummyClient(b"hi"))
+    monkeypatch.setattr(server, "parse_and_store_file", fake_parse)
+    monkeypatch.setattr(server, "reply_split", fake_reply_split)
+
+    msg = DummyMessage()
+    doc = DummyDocument("1")
+    await server._process_document(msg, doc)
+
+    assert outputs == []
+    assert called == []
+    assert msg.replies and "Unsupported file type" in msg.replies[0]


### PR DESCRIPTION
## Summary
- check downloaded Telegram documents for allowed extensions and reject others
- define allowed extensions `.txt`, `.md`, `.pdf`
- test allowed vs disallowed document uploads

## Testing
- `ruff check server.py tests/test_document_validation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c3dd66448329a7da35799e9165d8