### PR TITLE
Restrict plugin loading to allowlist and document registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ class HelloPlugin(BasePlugin):
 After saving the file, restart the server and send `/hello` in Telegram. Built-in
 plugins include the example `/search` command.
 
+To register a plugin, add its module name to `PLUGIN_ALLOWLIST` in
+`utils/plugins/__init__.py`. Only modules listed there are loaded.
+
 ### The 42 Utility
 
 The script hiding at `utils/plugins/42.py` animates Grokky's playful side. It

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,7 @@
 import importlib
 import sys
+from pathlib import Path
+
 import pytest
 
 
@@ -18,9 +20,32 @@ def test_plugin_discovery() -> None:
     assert any("search" in p.commands for p in plugins)
 
 
+def test_unknown_plugin_ignored() -> None:
+    plugin_dir = Path(__file__).resolve().parents[1] / "utils" / "plugins"
+    fake = plugin_dir / "malicious.py"
+    fake.write_text(
+        "from utils.plugins import BasePlugin\n"
+        "class Malicious(BasePlugin):\n"
+        "    def __init__(self):\n"
+        "        super().__init__()\n"
+        "        self.commands['evil'] = lambda _: 'bad'\n"
+    )
+    try:
+        plugins = _load()
+        assert all("evil" not in p.commands for p in plugins)
+    finally:
+        fake.unlink(missing_ok=True)
+
+
 @pytest.mark.asyncio
 async def test_command_routing(monkeypatch) -> None:
-    for mod in ["aiogram", "aiogram.types", "aiogram.enums", "aiogram.filters", "aiogram.exceptions"]:
+    for mod in [
+        "aiogram",
+        "aiogram.types",
+        "aiogram.enums",
+        "aiogram.filters",
+        "aiogram.exceptions",
+    ]:
         sys.modules.pop(mod, None)
     import server
     importlib.reload(server)

--- a/utils/plugins/__init__.py
+++ b/utils/plugins/__init__.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 from importlib import import_module
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List
+from typing import Awaitable, Callable, Dict, Iterable, List
 
 CommandHandler = Callable[[str], Awaitable[str]]
+
+
+PLUGIN_ALLOWLIST: Iterable[str] = ["42", "coder", "imagine", "web_search"]
 
 
 class BasePlugin:
@@ -17,13 +20,16 @@ class BasePlugin:
         self.commands = {}
 
 
-def load_plugins() -> List[BasePlugin]:
-    """Discover plugin classes and instantiate them."""
+def load_plugins(allowlist: Iterable[str] | None = None) -> List[BasePlugin]:
+    """Discover plugin classes from an allowlist and instantiate them."""
     plugins: List[BasePlugin] = []
     package = __name__
     base_path = Path(__file__).resolve().parent
+
+    allowed = {name.lower() for name in (allowlist or PLUGIN_ALLOWLIST)}
+
     for path in base_path.glob("[!_]*.py"):
-        if path.name == "__init__.py":
+        if path.name == "__init__.py" or path.stem.lower() not in allowed:
             continue
         module = import_module(f"{package}.{path.stem}")
         for obj in vars(module).values():
@@ -38,4 +44,4 @@ def load_plugins() -> List[BasePlugin]:
     return plugins
 
 
-__all__ = ["BasePlugin", "load_plugins", "CommandHandler"]
+__all__ = ["BasePlugin", "load_plugins", "CommandHandler", "PLUGIN_ALLOWLIST"]


### PR DESCRIPTION
## Summary
- load only approved plugin modules via `PLUGIN_ALLOWLIST`
- document plugin registration steps in README
- test discovery ignores files outside the allowlist

## Testing
- `flake8 utils/plugins/__init__.py tests/test_plugins.py`
- `pytest tests/test_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c3cec6dc83298dea731fa843c079