### PR TITLE
Limit GrokkyCoder conversation history

### DIFF
--- a/tests/test_coder_history.py
+++ b/tests/test_coder_history.py
@@ -1,0 +1,22 @@
+import pytest
+
+from utils.plugins.coder import GrokkyCoder
+
+
+class DummyClient:
+    class responses:
+        @staticmethod
+        def create(*args, **kwargs):
+            return type("R", (), {"output_text": "ok"})()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_history_trim(monkeypatch):
+    monkeypatch.setattr("utils.plugins.coder.client", DummyClient())
+    coder = GrokkyCoder()
+    total_calls = GrokkyCoder.MAX_HISTORY // 2 + 5
+    for i in range(total_calls):
+        await coder.chat(f"prompt {i}")
+    assert len(coder.history) == GrokkyCoder.MAX_HISTORY
+    expected_first = total_calls - GrokkyCoder.MAX_HISTORY // 2
+    assert coder.history[0] == f"prompt {expected_first}"

--- a/utils/plugins/coder.py
+++ b/utils/plugins/coder.py
@@ -31,8 +31,15 @@ class DraftResponse:
 class GrokkyCoder:
     """Stateful helper that analyzes and generates code."""
 
+    MAX_HISTORY = 20
+
     def __init__(self) -> None:
         self.history: List[str] = []
+
+    def _trim_history(self) -> None:
+        """Keep only the most recent history entries."""
+        if len(self.history) > self.MAX_HISTORY:
+            self.history = self.history[-self.MAX_HISTORY:]
 
     async def _ask(self, prompt: str) -> str:
         conversation = "\n".join(self.history + [prompt])
@@ -76,6 +83,7 @@ class GrokkyCoder:
 
         self.history.append(prompt)
         self.history.append(text)
+        self._trim_history()
         return text.strip()
 
     async def analyze(self, code_or_path: str | Path) -> str:
@@ -113,7 +121,6 @@ async def generate_code(request: str) -> DraftResponse:
 
 
 __all__ = ["interpret_code", "generate_code", "GrokkyCoder", "DraftResponse", "CoderPlugin"]
-
 
 
 class CoderPlugin(BasePlugin):


### PR DESCRIPTION
## Summary
- Cap `GrokkyCoder` history at 20 entries with new `_trim_history` helper
- Trim history after each conversation to prevent unbounded growth
- Add test ensuring history size never exceeds the limit

## Testing
- `flake8 utils/plugins/coder.py tests/test_coder_history.py --max-line-length=120`
- `pytest tests/test_coder_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c3ecb5cc8329a07163b2f31bcccc