### PR TITLE
Add automatic language detection and translation

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -457,6 +457,10 @@ jmp==0.0.4 \
     --hash=sha256:5dfeb0fd7c7a9f72a70fff0aab9d0cbfae32a809c02f4037ff3485ceb33e1730 \
     --hash=sha256:6aa7adbddf2bd574b28c7faf6e81a735eb11f53386447896909c6968dc36807d
     # via dm-haiku
+langdetect==1.0.9 \
+    --hash=sha256:7cbc0746252f19e76f77c0b1690aadf01963be835ef0cd4b56dddf2a8f1dfc2a \
+    --hash=sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
+    # via -r requirements.txt
 limits==5.4.0 \
     --hash=sha256:1afb03c0624cf004085532aa9524953f2565cf8b0a914e48dda89d172c13ceb7 \
     --hash=sha256:27ebf55118e3c9045f0dbc476f4559b26d42f4b043db670afb8963f36cf07fd9
@@ -1413,6 +1417,7 @@ six==1.17.0 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
     #   ebooklib
+    #   langdetect
     #   python-dateutil
     #   textract
 slowapi==0.1.9 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ jaxlib==0.7.0
 dm-haiku==0.0.14
 sentencepiece==0.2.0
 reportlab==4.4.3
+langdetect==1.0.9

--- a/utils/language.py
+++ b/utils/language.py
@@ -1,11 +1,21 @@
-import re
+"""Utilities for detecting text language."""
+
+from langdetect import DetectorFactory, LangDetectException, detect
+
+# Ensure deterministic results from langdetect
+DetectorFactory.seed = 0
 
 
 def detect_language(text: str) -> str:
-    """Detect language from ``text`` using simple heuristics.
+    """Detect the language of ``text``.
 
-    Returns ``"ru"`` if any Cyrillic characters are present, otherwise
-    returns ``"en"``. This lightweight detector avoids heavyweight
-    dependencies while enabling language-aware responses.
+    Uses the :mod:`langdetect` library to return an ISO 639-1 language code.
+    Falls back to ``"en"`` if detection fails.
     """
-    return "ru" if re.search(r"[А-Яа-я]", text) else "en"
+    try:
+        return detect(text)
+    except LangDetectException:
+        return "en"
+
+
+__all__ = ["detect_language"]


### PR DESCRIPTION
## Summary
- detect user language with `langdetect` and reuse in Telegram handler
- translate assistant replies to user language before responding
- depend on langdetect library

## Testing
- `python -m py_compile server.py utils/language.py`
- `flake8 server.py utils/language.py --select=E9,F63,F7,F82 --show-source --statistics`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ca6c1e44832995d9070b3e79c44f