### PR TITLE
Protect UI and command routes with API key

### DIFF
--- a/server.py
+++ b/server.py
@@ -904,7 +904,7 @@ async def feedback_endpoint(data: dict) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
-@app.get("/ui", response_class=HTMLResponse)
+@api_router.get("/ui", response_class=HTMLResponse)
 async def command_ui(request: Request) -> HTMLResponse:
     plugin_cmds = []
     for plugin in PLUGINS:
@@ -925,7 +925,7 @@ async def command_ui(request: Request) -> HTMLResponse:
     )
 
 
-@app.post("/command/{cmd}")
+@api_router.post("/command/{cmd}")
 async def run_command(cmd: str, args: str = "") -> JSONResponse:
     if cmd in STANDARD_COMMANDS:
         if cmd == "help":

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -23,10 +23,20 @@
   <pre id="output"></pre>
 
   <script>
+  let apiKey = null;
+  function getApiKey() {
+    if (!apiKey) {
+      apiKey = prompt('API Key', '');
+    }
+    return apiKey;
+  }
   async function runCommand(cmd) {
     const args = prompt('Arguments for /' + cmd, '');
     const url = '/command/' + cmd + (args ? '?args=' + encodeURIComponent(args) : '');
-    const resp = await fetch(url, {method: 'POST'});
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {'X-API-Key': getApiKey()}
+    });
     const data = await resp.json();
     document.getElementById('output').textContent = JSON.stringify(data, null, 2);
   }

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -37,3 +37,17 @@ def test_feedback_requires_api_key(app):
     client = TestClient(app)
     response = client.post("/feedback", json={})
     assert response.status_code == 401
+
+
+def test_ui_requires_api_key(app):
+    client = TestClient(app)
+    assert client.get("/ui").status_code == 401
+    resp = client.get("/ui", headers={"X-API-Key": "SECRET"})
+    assert resp.status_code == 200
+
+
+def test_command_requires_api_key(app):
+    client = TestClient(app)
+    assert client.post("/command/help").status_code == 401
+    resp = client.post("/command/help", headers={"X-API-Key": "SECRET"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- route `/ui` and `/command/{cmd}` are now mounted on `api_router` to enforce API key verification
- dashboard prompts for API key and sends it with command requests
- tests cover API key requirements for UI and command endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ca81e2648329a8bce1d20b606043