### PR TITLE
Validate file uploads

### DIFF
--- a/server.py
+++ b/server.py
@@ -883,8 +883,26 @@ async def handle_42_api(request: Request):
 
 @api_router.post("/file")
 async def handle_file_api(request: Request, file: UploadFile = File(...)):
+    filename = file.filename or ""
+    ext = Path(filename).suffix.lower()
+    if not ext:
+        ext = mimetypes.guess_extension(file.content_type or "") or ""
+    if ext not in ALLOWED_FILE_EXTENSIONS:
+        allowed = ", ".join(sorted(ALLOWED_FILE_EXTENSIONS))
+        return JSONResponse(
+            {"error": f"Unsupported file type. Allowed: {allowed}"},
+            status_code=400,
+        )
+
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        return JSONResponse(
+            {"error": f"File too large. Limit is {MAX_FILE_SIZE} bytes"},
+            status_code=400,
+        )
+
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(await file.read())
+        tmp.write(content)
         tmp_path = tmp.name
     try:
         result = await parse_and_store_file(tmp_path)

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -1,0 +1,79 @@
+import importlib
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def server_module(monkeypatch):
+    monkeypatch.setenv("API_KEY", "SECRET")
+    for mod in [
+        "aiogram",
+        "aiogram.types",
+        "aiogram.enums",
+        "aiogram.filters",
+        "aiogram.exceptions",
+    ]:
+        sys.modules.pop(mod, None)
+    import server
+    importlib.reload(server)
+    return server
+
+
+def _client(server_module):
+    return TestClient(server_module.app)
+
+
+def test_file_upload_ok(server_module, monkeypatch):
+    async def fake_parse(path):
+        return "PARSED"
+
+    monkeypatch.setattr(server_module, "parse_and_store_file", fake_parse)
+    client = _client(server_module)
+    resp = client.post(
+        "/file",
+        headers={"X-API-Key": "SECRET"},
+        files={"file": ("test.txt", b"hi", "text/plain")},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"result": "PARSED"}
+
+
+def test_file_upload_bad_extension(server_module, monkeypatch):
+    called = []
+
+    async def fake_parse(path):
+        called.append(path)
+        return "PARSED"
+
+    monkeypatch.setattr(server_module, "parse_and_store_file", fake_parse)
+    client = _client(server_module)
+    resp = client.post(
+        "/file",
+        headers={"X-API-Key": "SECRET"},
+        files={"file": ("test.exe", b"hi", "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+    assert "Unsupported file type" in resp.json()["error"]
+    assert called == []
+
+
+def test_file_upload_too_large(server_module, monkeypatch):
+    called = []
+
+    async def fake_parse(path):
+        called.append(path)
+        return "PARSED"
+
+    monkeypatch.setattr(server_module, "parse_and_store_file", fake_parse)
+    monkeypatch.setattr(server_module, "MAX_FILE_SIZE", 5)
+    client = _client(server_module)
+    resp = client.post(
+        "/file",
+        headers={"X-API-Key": "SECRET"},
+        files={"file": ("test.txt", b"123456", "text/plain")},
+    )
+    assert resp.status_code == 400
+    assert "File too large" in resp.json()["error"]
+    assert called == []


### PR DESCRIPTION
## Summary
- validate uploaded file extensions and sizes before processing
- return clear HTTP 400 errors for unsupported types or oversized files
- add tests covering valid uploads, bad extensions, and oversized files

## Testing
- `flake8 server.py tests/test_file_api.py` *(fails: line too long errors in server.py)*
- `pytest`
- `pytest tests/test_file_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6898ca900a888329ac9c2acf885b8021