### PR TITLE
feat: add localized command dashboard

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,74 @@
+let apiKey = null;
+let currentLang = 'en';
+const translations = {
+  en: {
+    title: 'Grokky Command Dashboard',
+    run: 'Run',
+    commandPlaceholder: 'Enter command',
+    argsFor: 'Arguments for',
+    apiKey: 'API Key',
+    networkError: 'Network error',
+    language: 'Language:'
+  },
+  ru: {
+    title: 'Панель команд Grokky',
+    run: 'Выполнить',
+    commandPlaceholder: 'Введите команду',
+    argsFor: 'Аргументы для',
+    apiKey: 'API-ключ',
+    networkError: 'Сетевая ошибка',
+    language: 'Язык:'
+  }
+};
+
+function t(key) {
+  return translations[currentLang][key] || key;
+}
+
+function getApiKey() {
+  if (!apiKey) {
+    apiKey = prompt(t('apiKey'), '');
+  }
+  return apiKey;
+}
+
+function setLang(lang) {
+  currentLang = lang;
+  document.getElementById('title').textContent = t('title');
+  document.getElementById('run-btn').textContent = t('run');
+  document.getElementById('command').placeholder = t('commandPlaceholder');
+  document.getElementById('lang-label').textContent = t('language');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const langSelect = document.getElementById('lang-select');
+  langSelect.addEventListener('change', () => setLang(langSelect.value));
+  setLang(langSelect.value);
+
+  const commandInput = document.getElementById('command');
+  const hint = document.getElementById('hint');
+  commandInput.addEventListener('input', () => {
+    hint.textContent = window.commandHints[commandInput.value] || '';
+  });
+
+  document.getElementById('run-btn').addEventListener('click', async () => {
+    const cmd = commandInput.value.trim();
+    if (!cmd) return;
+    const args = prompt(`${t('argsFor')} /${cmd}`, '');
+    const url = `/command/${cmd}${args ? `?args=${encodeURIComponent(args)}` : ''}`;
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'X-API-Key': getApiKey() }
+      });
+      const data = await resp.json();
+      if (!resp.ok) {
+        document.getElementById('output').textContent = data.error || 'Error';
+      } else {
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+      }
+    } catch (e) {
+      document.getElementById('output').textContent = `${t('networkError')}: ${e.message}`;
+    }
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,39 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: auto;
+  padding: 1rem;
+  background: #f5f5f5;
+}
+
+h1 {
+  text-align: center;
+}
+
+.command-input {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#command {
+  flex: 1;
+  padding: 0.5rem;
+}
+
+#run-btn {
+  padding: 0.5rem 1rem;
+}
+
+#hint {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+#output {
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  overflow: auto;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,45 +1,36 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Grokky Command Dashboard</title>
+  <link rel="stylesheet" href="{{ request.url_for('static', path='style.css') }}">
 </head>
 <body>
-  <h1>Grokky Command Dashboard</h1>
-  <h2>Standard Commands</h2>
-  <ul>
-  {% for cmd, desc in standard_commands.items() %}
-    <li><button onclick="runCommand('{{ cmd }}')">/{{ cmd }}</button> - {{ desc }}</li>
-  {% endfor %}
-  </ul>
-
-  <h2>Plugin Commands</h2>
-  <ul>
-  {% for c in plugin_commands %}
-    <li><button onclick="runCommand('{{ c.cmd }}')">/{{ c.cmd }}</button> - {{ c.desc }}</li>
-  {% endfor %}
-  </ul>
-
+  <h1 id="title">Grokky Command Dashboard</h1>
+  <div class="controls">
+    <label for="lang-select" id="lang-label">Language:</label>
+    <select id="lang-select">
+      <option value="en">English</option>
+      <option value="ru">Русский</option>
+    </select>
+  </div>
+  <div class="command-input">
+    <input id="command" list="commands" placeholder="Enter command" autocomplete="off" />
+    <datalist id="commands">
+      {% for cmd, desc in standard_commands.items() %}
+      <option value="{{ cmd }}" data-desc="{{ desc }}"></option>
+      {% endfor %}
+      {% for c in plugin_commands %}
+      <option value="{{ c.cmd }}" data-desc="{{ c.desc }}"></option>
+      {% endfor %}
+    </datalist>
+    <button id="run-btn">Run</button>
+  </div>
+  <div id="hint"></div>
   <pre id="output"></pre>
-
   <script>
-  let apiKey = null;
-  function getApiKey() {
-    if (!apiKey) {
-      apiKey = prompt('API Key', '');
-    }
-    return apiKey;
-  }
-  async function runCommand(cmd) {
-    const args = prompt('Arguments for /' + cmd, '');
-    const url = '/command/' + cmd + (args ? '?args=' + encodeURIComponent(args) : '');
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: {'X-API-Key': getApiKey()}
-    });
-    const data = await resp.json();
-    document.getElementById('output').textContent = JSON.stringify(data, null, 2);
-  }
+    window.commandHints = {{ command_hints | tojson }};
   </script>
+  <script src="{{ request.url_for('static', path='app.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add static mounting and command hint aggregation
- create localized dashboard with plugin autocomplete and hints
- add styling and script for translations and error handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ccf3c318832983a0d3ba4cdf5ee5