### PR TITLE
Integrate 42 plugin commands and summarize file uploads

### DIFF
--- a/utils/context_neural_processor.py
+++ b/utils/context_neural_processor.py
@@ -815,7 +815,7 @@ async def parse_and_store_file(
     log_event(
         f"Processed {os.path.basename(path)}: tags={tags}, summary={summary[:50]}..., relevance={relevance:.2f} (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
     )
-    return f"{text}\n\nTags: {tags}\nSummary: {summary}\nRelevance: {relevance:.2f}"
+    return f"Summary: {summary}\nTags: {tags}\nRelevance: {relevance:.2f}"
 
 async def create_repo_snapshot(base_path: str = ".", out_path: str = REPO_SNAPSHOT_PATH) -> None:
     handler = FileHandler()

--- a/utils/plugins/42.py
+++ b/utils/plugins/42.py
@@ -367,29 +367,26 @@ async def handle(cmd: str, lang: str = "en") -> Dict[str, str]:
 
 
 
-class WhenPlugin(BasePlugin):
-    name = "when"
-    description = "when"
+class FortyTwoPlugin(BasePlugin):
+    """Expose `/when`, `/mars` and `/42` commands to the bot."""
 
-    async def run(self, args: str) -> str:
+    def __init__(self) -> None:  # pragma: no cover - simple assignment
+        super().__init__()
+        self.commands = {
+            "when": self._when,
+            "mars": self._mars,
+            "42": self._forty_two,
+        }
+
+    async def _when(self, args: str) -> str:
         result = await handle("when")
         return result["response"]
 
-
-class MarsPlugin(BasePlugin):
-    name = "mars"
-    description = "why Mars?"
-
-    async def run(self, args: str) -> str:
+    async def _mars(self, args: str) -> str:
         result = await handle("mars")
         return result["response"]
 
-
-class FortyTwoPlugin(BasePlugin):
-    name = "42"
-    description = "answer"
-
-    async def run(self, args: str) -> str:
+    async def _forty_two(self, args: str) -> str:
         result = await handle("42")
         return result["response"]
 


### PR DESCRIPTION
## Summary
- expose `/when`, `/mars`, and `/42` through a unified plugin so they appear in the bot's command menu
- return short summaries for uploaded files instead of full text dumps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898cc3f19cc8329beda0c5bff8c1acc